### PR TITLE
Add log rotation and disk cleanup to prod workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -105,6 +105,8 @@ jobs:
             export IMAGE_NAME=ghcr.io/${{ github.repository }}
 
             docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml pull
-            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d --remove-orphans --force-recreate
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml down --remove-orphans
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d --force-recreate
 
-            docker image prune -f
+            docker builder prune -af
+            docker image prune -af

--- a/docs/superpowers/plans/2026-05-09-issue-57-disk-space-optimization.md
+++ b/docs/superpowers/plans/2026-05-09-issue-57-disk-space-optimization.md
@@ -1,0 +1,209 @@
+# Issue 57 Disk Space Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add log rotation to all production services and improve deploy script cleanup to prevent disk space exhaustion on the 10 GB droplet.
+
+**Architecture:** Two config-only files changed. Add `logging:` blocks to six services in `infra/docker-compose.prod.yml`, and extend the deploy script in `.github/workflows/docker-build-push.yml` with orphan cleanup and aggressive image/builder pruning. Verify with string-assertion regression tests in `tests/test_operational_files.py`.
+
+**Tech Stack:** Docker Compose v2, GitHub Actions, Python `unittest`.
+
+---
+
+## File Structure
+
+- Modify: `tests/test_operational_files.py` — new regression assertions
+- Modify: `infra/docker-compose.prod.yml` — log rotation on all services
+- Modify: `.github/workflows/docker-build-push.yml` — deploy cleanup improvements
+
+Only 3 files. No new files created, no files deleted.
+
+---
+
+### Task 1: Write failing regression tests
+
+**Files:**
+- Modify: `tests/test_operational_files.py`
+
+- [ ] **Step 1: Add failing assertions for logging and deploy cleanup**
+
+Append these 6 new test methods to the `OperationalFileTests` class in `tests/test_operational_files.py`, after the existing `test_makefile_uses_original_prod_project_name` method (line 68):
+
+```python
+    def test_prod_compose_all_services_have_logging(self):
+        content = (ROOT / "infra/docker-compose.prod.yml").read_text(encoding="utf-8")
+        self.assertEqual(content.count("    logging:"), 6)
+
+    def test_prod_compose_logging_has_rotation(self):
+        content = (ROOT / "infra/docker-compose.prod.yml").read_text(encoding="utf-8")
+        self.assertIn('max-size: "10m"', content)
+        self.assertIn('max-file: "3"', content)
+
+    def test_deploy_script_has_down_before_up(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        self.assertIn("down --remove-orphans", content)
+
+    def test_deploy_script_has_builder_prune(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        self.assertIn("docker builder prune -af", content)
+
+    def test_deploy_script_has_image_prune_all(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        self.assertIn("docker image prune -af", content)
+
+    def test_deploy_script_prune_runs_after_up(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        up_index = content.index("up -d --force-recreate")
+        prune_index = content.index("docker image prune -af")
+        self.assertGreater(prune_index, up_index)
+```
+
+- [ ] **Step 2: Run the regression tests to verify they fail**
+
+Run: `uv run python -m unittest tests.test_operational_files -v`
+
+Expected: 6 new tests FAIL, total 19 tests (13 pass + 6 fail), because:
+- prod compose has 0 `logging:` blocks (need 6)
+- deploy script has no `down --remove-orphans`
+- deploy script has no `docker builder prune -af`
+- deploy script has `docker image prune -f` (not `-af`)
+- deploy script doesn't have prune after up (only has `docker image prune -f`)
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/test_operational_files.py
+git commit -m "test: add regression coverage for issue 57 disk optimization"
+```
+
+---
+
+### Task 2: Implement compose logging and deploy cleanup
+
+**Files:**
+- Modify: `infra/docker-compose.prod.yml`
+- Modify: `.github/workflows/docker-build-push.yml`
+
+- [ ] **Step 1: Add logging rotation to all prod services**
+
+Add the following block after the `networks:` line of each of the 6 services in `infra/docker-compose.prod.yml`:
+
+```yaml
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+```
+
+The services are: `db` (ends at line 15), `redis` (ends at line 21), `web` (ends at line 59), `worker` (ends at line 94), `beat` (ends at line 126), `caddy` (ends at line 149).
+
+For example, `db` currently ends with:
+
+```yaml
+    networks:
+      - app-network
+```
+Add `logging:` block after `networks:` for each service.
+
+- [ ] **Step 2: Update the deploy script**
+
+Replace the final lines of the deploy script in `.github/workflows/docker-build-push.yml`:
+
+From:
+```yaml
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml pull
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d --remove-orphans --force-recreate
+
+            docker image prune -f
+```
+
+To (keeping exact 12-space indentation):
+```yaml
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml pull
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml down --remove-orphans
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d --force-recreate
+
+            docker builder prune -af
+            docker image prune -af
+```
+
+Note: `--remove-orphans` moves from `up` to `down`. `image prune -f` becomes `image prune -af`.
+
+- [ ] **Step 3: Run all regression tests to verify they pass**
+
+Run: `uv run python -m unittest tests.test_operational_files -v`
+
+Expected: all 19 file-level tests PASS.
+
+Run: `uv run python -m unittest tests.test_operational_helpers tests.test_operational_files -v`
+
+Expected: all 26 tests PASS (7 helper + 19 file-level).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/docker-compose.prod.yml .github/workflows/docker-build-push.yml
+git commit -m "feat: add log rotation and disk cleanup to prod workflow"
+```
+
+---
+
+### Task 3: Final verification
+
+**Files:**
+- Verify only: all files changed in Tasks 1-2
+
+- [ ] **Step 1: Validate both compose files parse**
+
+```bash
+docker compose -f infra/docker-compose.dev.yml config >/dev/null && echo "dev: OK" || echo "dev: FAIL"
+docker compose -f infra/docker-compose.prod.yml config >/dev/null && echo "prod: OK" || echo "prod: FAIL"
+```
+Expected: both OK.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+uv run python -m unittest tests.test_operational_helpers tests.test_operational_files -v
+```
+Expected: 26 tests, all PASS.
+
+- [ ] **Step 3: Run `make verify`**
+
+```bash
+make verify
+```
+Expected: PASS.
+
+- [ ] **Step 4: Check working tree is clean**
+
+```bash
+git status --short
+```
+Expected: no untracked/modified files.
+
+- [ ] **Step 5: Push**
+
+```bash
+git push origin feature/57-disk-space-optimization
+```
+
+---
+
+## Spec Coverage Check
+
+| Requirement | Task |
+|-------------|------|
+| Log rotation on all 6 prod services | Task 2 |
+| `max-size: 10m`, `max-file: 3` | Tasks 1-2 (tests + impl) |
+| `down --remove-orphans` before `up` in deploy | Tasks 1-2 |
+| `docker builder prune -af` in deploy | Tasks 1-2 |
+| `docker image prune -af` in deploy (all, not dangling) | Tasks 1-2 |
+| Verify passes | Task 3 |
+
+## Self-Review Notes
+
+- Placeholder scan: no unfinished markers or deferred implementation notes remain.
+- Scope check: 3 files, 2 config changes, 1 test file. Focused on Issue #57 only.
+- Naming consistency: `logging:`, `down --remove-orphans`, `builder prune -af`, `image prune -af` used consistently throughout.

--- a/docs/superpowers/specs/2026-05-09-issue-57-disk-space-optimization-design.md
+++ b/docs/superpowers/specs/2026-05-09-issue-57-disk-space-optimization-design.md
@@ -1,0 +1,90 @@
+# Disk Space Optimization Design (Issue #57)
+
+## Summary
+
+A 10 GB DigitalOcean droplet running this project accumulates disk usage from three preventable sources: unbounded container log growth, stale Docker images and build cache, and orphaned containers from previous failed deployments blocking cleanup. This design introduces log rotation, proactive image/cache pruning in the CI deploy script, and explicit orphan cleanup before bringing up new containers.
+
+## Goals
+
+- Cap container log growth with `json-file` rotation: `max-size: 10m`, `max-file: 3` on all six production services.
+- Clean build cache and unused images during every successful deploy.
+- Prevent port conflicts and disk waste from orphaned containers by running `docker compose down --remove-orphans` before `up`.
+- Keep the `Makefile` and dev compose unchanged.
+
+## Non-Goals
+
+- Adding disk space monitoring or alerting.
+- Changing the Docker storage driver or volume management.
+- Modifying development compose (`docker-compose.dev.yml`).
+
+## Proposed Changes
+
+### 1. Log rotation in `infra/docker-compose.prod.yml`
+
+Add a `logging` block to every service: `db`, `redis`, `web`, `worker`, `beat`, `caddy`.
+
+```yaml
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+```
+
+This limits each container to three 10 MB log files (30 MB per container). Total across six containers: approximately 180 MB maximum, compared to unbounded growth today.
+
+### 2. CI deploy script cleanup
+
+Replace the end of the deploy script in `.github/workflows/docker-build-push.yml`.
+
+**Before:**
+```yaml
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml pull
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d --remove-orphans --force-recreate
+            docker image prune -f
+```
+
+**After:**
+```yaml
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml pull
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml down --remove-orphans
+            docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d --force-recreate
+            docker builder prune -af
+            docker image prune -af
+```
+
+Key differences:
+- `down --remove-orphans` runs before `up`, ensuring any leftover containers (e.g. from other Compose projects like `infra-*`) are removed and their ports freed.
+- `--remove-orphans` on `up` is removed — it is redundant after `down`.
+- `docker builder prune -af` clears all Docker build cache, which was measured at ~1.1 GB on the droplet.
+- `docker image prune -af` replaces `-f` (dangling only) — `-a` removes all unused images, including old versions of `:latest`.
+
+### 3. No changes to dev compose or Makefile
+
+Development targets and the development compose file are unchanged. Log rotation is not needed locally because dev containers are ephemeral and the development host is not disk-constrained.
+
+## Expected Disk Impact
+
+| Source | Before | After |
+|--------|--------|-------|
+| Container logs | unbounded growth | ≤ 180 MB total |
+| Build cache | ~1.1 GB uncleaned | cleaned every deploy |
+| Old images | ~2.2 GB reclaimable (measured) | cleaned every deploy |
+| Orphaned containers | accumulate on failed deploy | removed before every `up` |
+
+## Error Handling
+
+- `docker compose down` is idempotent — it exits 0 even when no containers match the project name.
+- `docker builder prune -af` and `docker image prune -af` are safe: they only remove unused objects, never active containers or their images.
+- Log rotation is handled by the Docker daemon, not the container — no change to application behavior.
+
+## Testing Strategy
+
+- `make verify` must pass unchanged.
+- `uv run python -m unittest tests.test_operational_files -v` must pass.
+- Both compose files must parse: `docker compose -f infra/docker-compose.dev.yml config`, `docker compose -f infra/docker-compose.prod.yml config`.
+- No new tests are required — the changes are configuration-only.
+
+## Rationale
+
+The three changes address the three independently measured disk consumers on the droplet: logs (unbounded), build cache (~1.1 GB), and old images (~2.2 GB). The orphan cleanup prevents a recurring failure mode where a prior failed deploy left containers that blocked ports and held references to volumes, breaking the next deploy. All changes are production-only; the development workflow is untouched.

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -13,12 +13,22 @@ services:
       - postgres_data:/var/lib/postgresql/data
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   redis:
     image: redis:7-alpine
     restart: always
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   web:
     build:
@@ -57,6 +67,11 @@ services:
       - redis
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   worker:
     build:
@@ -92,6 +107,11 @@ services:
       - web
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   beat:
     build:
@@ -124,6 +144,11 @@ services:
       - redis
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   caddy:
     image: caddy:2
@@ -146,6 +171,11 @@ services:
       - web
     networks:
       - app-network
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 networks:
   app-network:

--- a/tests/test_operational_files.py
+++ b/tests/test_operational_files.py
@@ -67,6 +67,33 @@ class OperationalFileTests(unittest.TestCase):
         content = (ROOT / "Makefile").read_text(encoding="utf-8")
         self.assertIn("-p my_django_portfolio", content)
 
+    def test_prod_compose_all_services_have_logging(self):
+        content = (ROOT / "infra/docker-compose.prod.yml").read_text(encoding="utf-8")
+        self.assertEqual(content.count("    logging:"), 6)
+
+    def test_prod_compose_logging_has_rotation(self):
+        content = (ROOT / "infra/docker-compose.prod.yml").read_text(encoding="utf-8")
+        self.assertIn('max-size: "10m"', content)
+        self.assertIn('max-file: "3"', content)
+
+    def test_deploy_script_has_down_before_up(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        self.assertIn("down --remove-orphans", content)
+
+    def test_deploy_script_has_builder_prune(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        self.assertIn("docker builder prune -af", content)
+
+    def test_deploy_script_has_image_prune_all(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        self.assertIn("docker image prune -af", content)
+
+    def test_deploy_script_prune_runs_after_up(self):
+        content = (ROOT / ".github/workflows/docker-build-push.yml").read_text(encoding="utf-8")
+        up_index = content.index("up -d --force-recreate")
+        prune_index = content.index("docker image prune -af")
+        self.assertGreater(prune_index, up_index)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
- Added `json-file` log rotation (`max-size: 10m`, `max-file: 3`) to all 6 production services in `docker-compose.prod.yml`
- Added `docker compose down --remove-orphans` before `up` in the CI deploy script
- Added `docker builder prune -af` and `docker image prune -af` after `up` in the CI deploy script
- Added 6 regression tests verifying each change

## Why
The 10 GB droplet accumulates unbounded container logs, stale build cache (~1.1 GB), and old Docker images (~2.2 GB), causing disk exhaustion. This caps log growth at ~180 MB total and cleans build cache + unused images on every deploy.

Closes #57

## How
- `infra/docker-compose.prod.yml`: Added `logging:` block with `json-file` driver to `db`, `redis`, `web`, `worker`, `beat`, `caddy`
- `.github/workflows/docker-build-push.yml`: Replaced `up -d --remove-orphans` with `down --remove-orphans` → `up -d --force-recreate`; added `docker builder prune -af` and `docker image prune -af`
- `tests/test_operational_files.py`: 6 new string-assertion tests

## Testing
- `make verify` passes
- `uv run python -m unittest tests.test_operational_helpers tests.test_operational_files -v` — 26/26 pass
- Both compose files parse: `docker compose -f infra/docker-compose.prod.yml config` succeeds
- No dev compose or Makefile changes

## Risk
- **Brief downtime per deploy.** The old `up --force-recreate` did a rolling replace; the new `down` → `up` sequence stops all containers before starting new ones, causing a few seconds of unavailability. This is necessary for correct orphan cleanup and port-conflict prevention.
- `docker image prune -af` removes all unused images, not just dangling ones. This is intentional but more aggressive than before.

## Rollback
Revert to the previous deploy script (restore `--remove-orphans` on `up` instead of `down`, drop `builder prune`, change `image prune -af` back to `-f`) and remove `logging:` blocks from the prod compose.