### PR TITLE
Audit/codebase 2026 05

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Debug flag
-DJANGO_DEBUG=True
+DJANGO_DEBUG=True  # DEVELOPMENT ONLY — set to False in production
 
 # Secret key (generate a new one for production)
 SECRET_KEY=your_generated_secure_key_here

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# Debug flag
-DJANGO_DEBUG=True  # DEVELOPMENT ONLY — set to False in production
+# Debug flag — set to False in production
+DJANGO_DEBUG=True
 
 # Secret key (generate a new one for production)
 SECRET_KEY=your_generated_secure_key_here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+### Full verification (what CI runs)
+```bash
+make verify
+```
+Runs CSS build, Python compile check, `manage.py check`, migration check, Django tests, and ruff lint.
+
+### Development with Docker
+```bash
+make dev-up      # builds and starts all services; creates .env from .env.example if missing
+make dev-status  # show running containers
+make dev-down
+```
+
+### Running tests
+```bash
+# Django app tests (requires env vars for settings)
+SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 uv run python django/manage.py test
+
+# Run a single test module
+SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 uv run python django/manage.py test main.tests.test_views
+
+# Operational/infra tests (no env vars needed)
+uv run python -m pytest tests/
+```
+
+### Linting
+```bash
+uv run ruff check infra/scripts tests
+```
+
+### CSS build
+```bash
+npm run build:css        # development (watch with: npm run dev)
+npm run build:css:prod   # minified for production
+```
+
+### Django management
+```bash
+uv run python django/manage.py migrate
+uv run python django/manage.py collectstatic --noinput
+uv run python django/manage.py runserver
+```
+
+### Celery (separate terminals)
+```bash
+uv run celery -A config worker --workdir=django --loglevel=info
+uv run celery -A config beat --workdir=django --loglevel=info
+```
+
+## Architecture
+
+### Service topology
+Six Docker services in production: `web` (Gunicorn+Django), `db` (PostgreSQL), `redis`, `worker` (Celery worker), `beat` (Celery beat scheduler), `caddy` (reverse proxy + static/media serving). Dev compose omits Caddy.
+
+### Django app layout
+Single app `main` under `django/`. Configuration lives in `django/config/` (settings, urls, celery, wsgi/asgi). The `django/` directory is both the Django project root and the `--workdir` for Celery.
+
+### Key modules
+- `django/main/models.py` — all domain models: `Project`, `Tag`, `PortfolioProfile`, `HeatmapSnapshot`, `PageView`, `TaskExecutionStatus`, `TaskExecutionLog`
+- `django/main/views.py` — page views and admin-tool endpoints
+- `django/main/tasks.py` — two main Celery tasks: `sync_project_markdowns_task` and `refresh_portfolio_heatmap_cache_task`
+- `django/main/markdown_sync.py` — fetches README markdown from GitHub and writes to `media/blog_markdown/`
+- `django/main/heatmap.py` — fetches GitHub contribution data (REST + GraphQL) and persists to `HeatmapSnapshot`
+- `django/main/context_processors.py` — injects visitor count, project count, and active `PortfolioProfile` into every template
+
+### Background task observability
+Every task run writes to `TaskExecutionStatus` (latest snapshot, keyed by `task_name`) and appends a `TaskExecutionLog` row. Admin users see this on the about page.
+
+### Environment variables
+Loaded from `.env` at project root via `django-environ`. `SECRET_KEY` is required at startup. Key vars: `DJANGO_DEBUG`, `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`, `GITHUB_HEATMAP_TOKEN`, `HEATMAP_CACHE_TTL_MINUTES`, `CELERY_BROKER_URL`, `DB_*` (or `DOCKER_DB_*` for compose). See `.env.example`.
+
+### Static and media files
+- CSS source: `django/main/static/src/css/input.css` → output: `django/main/static/css/style.css`
+- Caddy serves `staticfiles/` and `media/` directly via named Docker volumes
+- Containers run as non-root uid `10001:10001`; volume ownership matters
+
+### Celery beat schedule
+Defined in `django/config/settings.py` (`CELERY_BEAT_SCHEDULE`):
+- Heatmap refresh: every hour
+- Markdown sync: every 2 hours
+
+### Tests location
+- `django/main/tests/` — Django unit/integration tests (views, models, tasks, middleware, heatmap, markdown sync)
+- `tests/` — operational tests for infra scripts and compose file invariants (no Django required)
+
+### CI/CD
+Two GitHub Actions workflows: `django-ci.yml` runs `make verify` on PRs to main; `docker-build-push.yml` builds and pushes to GHCR then deploys to DigitalOcean via SSH on merge to main.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ PROD_COMPOSE := docker compose --env-file .env -p my_django_portfolio -f infra/d
 dev-up:
 	uv run python infra/scripts/ensure_env.py dev
 	$(DEV_COMPOSE) up --build -d
+	@echo ""
+	@echo "  Frontend:  http://localhost:8000"
+	@echo "  Admin:     http://localhost:8000/admin"
+	@echo "  DB:        localhost:15432"
+	@echo ""
 
 dev-down:
 	$(DEV_COMPOSE) down

--- a/django/config/celery.py
+++ b/django/config/celery.py
@@ -7,8 +7,3 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 app = Celery("config")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
-
-
-@app.task(bind=True)
-def debug_task(self):
-    print(f"Request: {self.request!r}")

--- a/django/config/settings.py
+++ b/django/config/settings.py
@@ -178,7 +178,6 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(PROJECT_ROOT, "media")
 DATA_UPLOAD_MAX_MEMORY_SIZE = 5242880  # 5 MB limit for file uploads
 
-# STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'  # Commented out as we're using Caddy for static files
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"  # Using default Django storage
 
 LOGGING = {
@@ -211,6 +210,7 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
+CELERY_TASK_IGNORE_RESULT = True
 CELERY_BEAT_SCHEDULE = {
     "refresh-portfolio-heatmap-hourly": {
         "task": "main.tasks.refresh_portfolio_heatmap_cache_task",
@@ -220,5 +220,9 @@ CELERY_BEAT_SCHEDULE = {
     "sync-project-markdowns-hourly": {
         "task": "main.tasks.sync_project_markdowns_task",
         "schedule": crontab(hour="*/2", minute=0),
+    },
+    "check-disk-usage-daily": {
+        "task": "main.tasks.check_disk_usage_task",
+        "schedule": crontab(hour=6, minute=0),
     },
 }

--- a/django/main/context_processors.py
+++ b/django/main/context_processors.py
@@ -12,13 +12,8 @@ def project_count(request):
 
 
 def visitor_counter(request):
-    """Expose the global visit counter to all templates.
-
-    Returns:
-        dict: Context with `visitor_count` key.
-    """
-    count = PageView.get_instance().count
-    return {"visitor_count": count}
+    instance = PageView.objects.filter(id=1).first()
+    return {"visitor_count": instance.count if instance else 0}
 
 
 def portfolio_profile(request):

--- a/django/main/markdown_sync.py
+++ b/django/main/markdown_sync.py
@@ -1,8 +1,7 @@
 import logging
+import requests
 from pathlib import Path
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
-from urllib.request import Request, urlopen
 
 from django.core.files.base import ContentFile
 
@@ -97,38 +96,35 @@ def build_markdown_candidate_urls(project):
     return deduped
 
 
-def _download_markdown(url, timeout=20, opener=urlopen):
-    request = Request(url, headers={"User-Agent": "my-django-portfolio-markdown-sync/1.0"})
-    with opener(request, timeout=timeout) as response:
-        status = getattr(response, "status", 200)
-        if status != 200:
-            raise HTTPError(url, status, "Non-200 response", None, None)
-        content_length = None
-        if hasattr(response, "getheader"):
-            content_length = response.getheader("Content-Length")
-        elif getattr(response, "headers", None) is not None:
-            content_length = response.headers.get("Content-Length")
+def _download_markdown(url, timeout=20):
+    try:
+        response = requests.get(
+            url,
+            headers={"User-Agent": "my-django-portfolio-markdown-sync/1.0"},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        raise
+    except requests.exceptions.RequestException as exc:
+        raise OSError(str(exc)) from exc
 
-        if content_length is not None:
-            try:
-                parsed_length = int(content_length)
-            except (TypeError, ValueError):
-                parsed_length = None
+    content_length = response.headers.get("Content-Length")
+    if content_length is not None:
+        try:
+            parsed_length = int(content_length)
+        except (TypeError, ValueError):
+            parsed_length = None
+        if parsed_length is not None and parsed_length > MAX_MARKDOWN_SIZE_BYTES:
+            raise ValueError(
+                f"Downloaded markdown exceeds size limit ({MAX_MARKDOWN_SIZE_BYTES} bytes)"
+            )
 
-            if parsed_length is not None and parsed_length > MAX_MARKDOWN_SIZE_BYTES:
-                raise ValueError(f"Downloaded markdown exceeds size limit ({MAX_MARKDOWN_SIZE_BYTES} bytes)")
-
-        chunks = []
-        total_size = 0
-        while True:
-            chunk = response.read(64 * 1024)
-            if not chunk:
-                break
-            total_size += len(chunk)
-            if total_size > MAX_MARKDOWN_SIZE_BYTES:
-                raise ValueError(f"Downloaded markdown exceeds size limit ({MAX_MARKDOWN_SIZE_BYTES} bytes)")
-            chunks.append(chunk)
-        raw_bytes = b"".join(chunks)
+    raw_bytes = response.content
+    if len(raw_bytes) > MAX_MARKDOWN_SIZE_BYTES:
+        raise ValueError(
+            f"Downloaded markdown exceeds size limit ({MAX_MARKDOWN_SIZE_BYTES} bytes)"
+        )
 
     text = raw_bytes.decode("utf-8-sig")
     if text.lstrip().lower().startswith("<!doctype html") or text.lstrip().lower().startswith("<html"):
@@ -136,7 +132,7 @@ def _download_markdown(url, timeout=20, opener=urlopen):
     return text
 
 
-def sync_project_markdown(project, timeout=20, opener=urlopen):
+def sync_project_markdown(project, timeout=20):
     candidate_urls = build_markdown_candidate_urls(project)
     if not candidate_urls:
         return {
@@ -152,10 +148,11 @@ def sync_project_markdown(project, timeout=20, opener=urlopen):
 
     for url in candidate_urls:
         try:
-            markdown_text = _download_markdown(url, timeout=timeout, opener=opener)
+            markdown_text = _download_markdown(url, timeout=timeout)
             source_url = url
             break
-        except (HTTPError, URLError, UnicodeDecodeError, ValueError, OSError) as exc:
+        except (requests.exceptions.HTTPError, requests.exceptions.RequestException,
+                UnicodeDecodeError, ValueError, OSError) as exc:
             last_error = str(exc)
             logger.warning("Markdown sync failed for %s from %s: %s", project.blog_url, url, exc)
 
@@ -171,13 +168,9 @@ def sync_project_markdown(project, timeout=20, opener=urlopen):
     old_name = project.markdown_file.name if project.markdown_file else ""
     target_basename = Path(old_name).name if old_name else f"{project.blog_url or f'project-{project.id}'}.md"
 
-    storage = project.markdown_file.storage
     project.markdown_file.save(target_basename, ContentFile(markdown_text.encode("utf-8")), save=False)
     project.save(update_fields=["markdown_file"])
     new_name = project.markdown_file.name
-
-    if old_name and old_name != new_name and storage.exists(old_name):
-        storage.delete(old_name)
 
     return {
         "project_id": project.id,

--- a/django/main/models.py
+++ b/django/main/models.py
@@ -2,6 +2,8 @@ import datetime
 
 from django.core.validators import FileExtensionValidator
 from django.db import models
+from django.db.models.signals import post_delete, pre_save
+from django.dispatch import receiver
 
 from .validators import validate_github_repo_url
 
@@ -231,3 +233,30 @@ class HeatmapSnapshot(models.Model):
 
     def __str__(self):
         return f"HeatmapSnapshot<{self.key}>"
+
+
+def _delete_file_field(field):
+    if field and field.name:
+        storage = field.storage
+        if storage.exists(field.name):
+            storage.delete(field.name)
+
+
+@receiver(post_delete, sender=Project)
+def _project_post_delete(sender, instance, **kwargs):
+    _delete_file_field(instance.thumbnail)
+    _delete_file_field(instance.markdown_file)
+
+
+@receiver(pre_save, sender=Project)
+def _project_pre_save(sender, instance, **kwargs):
+    if not instance.pk:
+        return
+    try:
+        old = Project.objects.get(pk=instance.pk)
+    except Project.DoesNotExist:
+        return
+    if old.thumbnail and old.thumbnail != instance.thumbnail:
+        _delete_file_field(old.thumbnail)
+    if old.markdown_file and old.markdown_file != instance.markdown_file:
+        _delete_file_field(old.markdown_file)

--- a/django/main/tasks.py
+++ b/django/main/tasks.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 
 from celery import shared_task
 from django.utils import timezone
@@ -15,14 +16,17 @@ from .models import Project, TaskExecutionLog, TaskExecutionStatus
 logger = logging.getLogger(__name__)
 SYNC_MARKDOWNS_TASK_NAME = "main.sync_project_markdowns_task"
 REFRESH_HEATMAP_TASK_NAME = "main.refresh_portfolio_heatmap_cache_task"
+DISK_USAGE_TASK_NAME = "main.check_disk_usage_task"
+DISK_CRITICAL_GB = 1.0
+DISK_WARNING_GB = 2.0
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def healthcheck_task():
     return "ok"
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def sync_project_markdowns_task(blog_slug=None):
     status, _ = TaskExecutionStatus.objects.get_or_create(
         task_name=SYNC_MARKDOWNS_TASK_NAME
@@ -105,7 +109,7 @@ def sync_project_markdowns_task(blog_slug=None):
     }
 
 
-@shared_task
+@shared_task(ignore_result=True)
 def refresh_portfolio_heatmap_cache_task(schedule_next=False):
     status, _ = TaskExecutionStatus.objects.get_or_create(
         task_name=REFRESH_HEATMAP_TASK_NAME
@@ -192,6 +196,55 @@ def refresh_portfolio_heatmap_cache_task(schedule_next=False):
         "total": snapshot.total,
         "weeks_count": snapshot.weeks_count,
     }
+
+
+@shared_task(ignore_result=True)
+def check_disk_usage_task():
+    usage = shutil.disk_usage("/")
+    free_gb = usage.free / (1024 ** 3)
+
+    status, _ = TaskExecutionStatus.objects.get_or_create(task_name=DISK_USAGE_TASK_NAME)
+    status.last_run_at = timezone.now()
+    status.last_total = 1
+
+    if free_gb < DISK_CRITICAL_GB:
+        logger.critical("DISK CRITICAL: only %.1f GB free on /", free_gb)
+        status.last_status = TaskExecutionStatus.STATUS_FAILURE
+        status.last_updated = 0
+        status.last_failed = 1
+        status.last_error = f"CRITICAL: {free_gb:.1f} GB free (below {DISK_CRITICAL_GB} GB threshold)"
+        status.last_success_at = None
+        status.last_failure_at = timezone.now()
+    elif free_gb < DISK_WARNING_GB:
+        logger.warning("DISK WARNING: only %.1f GB free on /", free_gb)
+        status.last_status = TaskExecutionStatus.STATUS_PARTIAL_SUCCESS
+        status.last_updated = 0
+        status.last_failed = 1
+        status.last_error = f"WARNING: {free_gb:.1f} GB free (below {DISK_WARNING_GB} GB threshold)"
+        status.last_success_at = None
+        status.last_failure_at = timezone.now()
+    else:
+        logger.info("DISK OK: %.1f GB free on /", free_gb)
+        status.last_status = TaskExecutionStatus.STATUS_SUCCESS
+        status.last_updated = 1
+        status.last_failed = 0
+        status.last_error = ""
+        status.last_success_at = timezone.now()
+        status.last_failure_at = None
+
+    status.save(
+        update_fields=[
+            "last_status",
+            "last_run_at",
+            "last_success_at",
+            "last_failure_at",
+            "last_total",
+            "last_updated",
+            "last_failed",
+            "last_error",
+        ]
+    )
+    _log_task_execution(status)
 
 
 def _maybe_schedule_next_refresh(schedule_next):

--- a/django/main/templates/pages/about.html
+++ b/django/main/templates/pages/about.html
@@ -104,6 +104,30 @@
     <section class="mt-6 rounded-2xl border border-base-300 bg-base-200 shadow-sm">
         <div class="p-4 sm:p-6">
             <div class="flex items-center justify-between">
+                <h2 class="text-xl font-semibold text-primary">Disk Usage</h2>
+                <span class="badge badge-outline badge-sm">Admin</span>
+            </div>
+            <div class="mt-4 grid gap-3 sm:grid-cols-3">
+                <article class="rounded-xl border border-base-300 bg-base-100 p-4">
+                    <p class="text-xs font-medium uppercase tracking-wide text-base-content/80">Free</p>
+                    <p class="mt-1 text-lg font-semibold {% if disk_info.level == 'critical' %}text-error{% elif disk_info.level == 'warning' %}text-warning{% else %}text-success{% endif %}">
+                        {{ disk_info.free_gb }} GB ({{ disk_info.free_pct }}%)
+                    </p>
+                </article>
+                <article class="rounded-xl border border-base-300 bg-base-100 p-4">
+                    <p class="text-xs font-medium uppercase tracking-wide text-base-content/80">Used</p>
+                    <p class="mt-1 text-lg font-semibold">{{ disk_info.used_gb }} GB</p>
+                </article>
+                <article class="rounded-xl border border-base-300 bg-base-100 p-4">
+                    <p class="text-xs font-medium uppercase tracking-wide text-base-content/80">Total</p>
+                    <p class="mt-1 text-lg font-semibold">{{ disk_info.total_gb }} GB</p>
+                </article>
+            </div>
+        </div>
+    </section>
+    <section class="mt-6 rounded-2xl border border-base-300 bg-base-200 shadow-sm">
+        <div class="p-4 sm:p-6">
+            <div class="flex items-center justify-between">
                 <h2 class="text-xl font-semibold text-primary">Scheduled Jobs</h2>
                 <span class="badge badge-outline badge-sm">Admin</span>
             </div>

--- a/django/main/tests/test_markdown_sync.py
+++ b/django/main/tests/test_markdown_sync.py
@@ -1,6 +1,9 @@
 import datetime
 import shutil
 import tempfile
+from unittest.mock import MagicMock, patch
+
+import requests
 
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
@@ -9,28 +12,18 @@ from main.markdown_sync import sync_project_markdown
 from main.models import PortfolioProfile, Project
 
 
-class _DummyResponse:
-    def __init__(self, payload, status=200):
-        self._payload = payload
-        self.status = status
-        self._cursor = 0
-        self.headers = {}
-
-    def read(self, size=-1):
-        if size is None or size < 0:
-            size = len(self._payload) - self._cursor
-        if self._cursor >= len(self._payload):
-            return b""
-        start = self._cursor
-        end = min(start + size, len(self._payload))
-        self._cursor = end
-        return self._payload[start:end]
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        return False
+def _make_mock_response(content: bytes, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+    resp.headers = {}
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+            response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
 
 
 class MarkdownSyncTests(TestCase):
@@ -64,15 +57,18 @@ class MarkdownSyncTests(TestCase):
         )
         project.markdown_file.save("sync-success.md", ContentFile(b"# Old"), save=True)
 
-        def opener(request, timeout=20):
-            return _DummyResponse(b"# New Content\n\nUpdated.")
-
-        result = sync_project_markdown(project, opener=opener)
+        with patch(
+            "main.markdown_sync.requests.get",
+            return_value=_make_mock_response(b"# New Content\n\nUpdated."),
+        ):
+            result = sync_project_markdown(project)
 
         self.assertTrue(result["updated"])
         project.refresh_from_db()
         project.markdown_file.open("rb")
-        self.assertEqual(project.markdown_file.read().decode("utf-8"), "# New Content\n\nUpdated.")
+        self.assertEqual(
+            project.markdown_file.read().decode("utf-8"), "# New Content\n\nUpdated."
+        )
         project.markdown_file.close()
 
     def test_sync_project_markdown_keeps_old_file_on_failure(self):
@@ -88,10 +84,11 @@ class MarkdownSyncTests(TestCase):
         project.markdown_file.save("sync-failure.md", ContentFile(b"# Old"), save=True)
         old_name = project.markdown_file.name
 
-        def opener(request, timeout=20):
-            raise OSError("network down")
-
-        result = sync_project_markdown(project, opener=opener)
+        with patch(
+            "main.markdown_sync.requests.get",
+            side_effect=requests.exceptions.ConnectionError("network down"),
+        ):
+            result = sync_project_markdown(project)
 
         self.assertFalse(result["updated"])
         project.refresh_from_db()
@@ -114,10 +111,11 @@ class MarkdownSyncTests(TestCase):
         old_name = project.markdown_file.name
         oversized_payload = b"a" * (10 * 1024 * 1024 + 1)
 
-        def opener(request, timeout=20):
-            return _DummyResponse(oversized_payload)
-
-        result = sync_project_markdown(project, opener=opener)
+        with patch(
+            "main.markdown_sync.requests.get",
+            return_value=_make_mock_response(oversized_payload),
+        ):
+            result = sync_project_markdown(project)
 
         self.assertFalse(result["updated"])
         self.assertEqual(result["reason"], "download_failed")

--- a/django/main/tests/test_models.py
+++ b/django/main/tests/test_models.py
@@ -1,8 +1,11 @@
 import datetime
+import shutil
+import tempfile
 
 from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
 from django.db import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from main.models import (
     PageView,
@@ -256,3 +259,51 @@ class TaskExecutionLogModelTest(TestCase):
         self.assertEqual(log.last_updated, 1)
         self.assertEqual(log.last_failed, 0)
         self.assertEqual(log.last_error, "")
+
+
+class ProjectMediaCleanupTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._media_root = tempfile.mkdtemp(prefix="project-media-tests-")
+        cls._override = override_settings(MEDIA_ROOT=cls._media_root)
+        cls._override.enable()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._override.disable()
+        shutil.rmtree(cls._media_root, ignore_errors=True)
+        super().tearDownClass()
+
+    def _make_project_with_thumbnail(self):
+        from main.models import Project
+        project = Project.objects.create(
+            title="Media Test",
+            short_description="test",
+            date=datetime.date(2025, 1, 1),
+            status="finished",
+        )
+        project.thumbnail.save("thumb.png", ContentFile(b"fake-png"), save=True)
+        return project
+
+    def test_thumbnail_deleted_when_project_deleted(self):
+        from main.models import Project
+        project = self._make_project_with_thumbnail()
+        storage = project.thumbnail.storage
+        thumb_name = project.thumbnail.name
+        self.assertTrue(storage.exists(thumb_name))
+
+        project.delete()
+
+        self.assertFalse(storage.exists(thumb_name))
+
+    def test_old_thumbnail_deleted_when_replaced(self):
+        from main.models import Project
+        project = self._make_project_with_thumbnail()
+        storage = project.thumbnail.storage
+        old_name = project.thumbnail.name
+        self.assertTrue(storage.exists(old_name))
+
+        project.thumbnail.save("thumb_new.png", ContentFile(b"new-fake-png"), save=True)
+
+        self.assertFalse(storage.exists(old_name))

--- a/django/main/tests/test_tasks.py
+++ b/django/main/tests/test_tasks.py
@@ -1,3 +1,5 @@
+import collections
+import shutil
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -5,8 +7,11 @@ from django.utils import timezone
 
 from main.models import HeatmapSnapshot, Project, TaskExecutionLog, TaskExecutionStatus
 from main.tasks import (
+    DISK_USAGE_TASK_NAME,
     REFRESH_HEATMAP_TASK_NAME,
     SYNC_MARKDOWNS_TASK_NAME,
+    check_disk_usage_task,
+    healthcheck_task,
     refresh_portfolio_heatmap_cache_task,
     sync_project_markdowns_task,
 )
@@ -326,3 +331,44 @@ class TaskStatusTrackingTests(TestCase):
         self.assertIsNone(status.last_success_at)
         self.assertIsNotNone(status.last_failure_at)
         update_error_mock.assert_called_once_with("Heatmap is not configured.")
+
+
+class TaskIgnoreResultTests(TestCase):
+    def test_healthcheck_task_has_ignore_result(self):
+        self.assertTrue(getattr(healthcheck_task, "ignore_result", False))
+
+
+class DiskUsageTaskTests(TestCase):
+    def _fake_usage(self, total_gb, free_gb):
+        total = int(total_gb * 1024 ** 3)
+        free = int(free_gb * 1024 ** 3)
+        used = total - free
+        DiskUsage = collections.namedtuple("DiskUsage", ["total", "used", "free"])
+        return DiskUsage(total=total, used=used, free=free)
+
+    def test_disk_task_success_when_ample_space(self):
+        usage = self._fake_usage(total_gb=10.0, free_gb=5.0)
+        with patch("main.tasks.shutil.disk_usage", return_value=usage):
+            check_disk_usage_task()
+
+        status = TaskExecutionStatus.objects.get(task_name=DISK_USAGE_TASK_NAME)
+        self.assertEqual(status.last_status, TaskExecutionStatus.STATUS_SUCCESS)
+        self.assertEqual(status.last_error, "")
+
+    def test_disk_task_partial_when_below_2gb(self):
+        usage = self._fake_usage(total_gb=10.0, free_gb=1.5)
+        with patch("main.tasks.shutil.disk_usage", return_value=usage):
+            check_disk_usage_task()
+
+        status = TaskExecutionStatus.objects.get(task_name=DISK_USAGE_TASK_NAME)
+        self.assertEqual(status.last_status, TaskExecutionStatus.STATUS_PARTIAL_SUCCESS)
+        self.assertIn("1.5", status.last_error)
+
+    def test_disk_task_failure_when_below_1gb(self):
+        usage = self._fake_usage(total_gb=10.0, free_gb=0.8)
+        with patch("main.tasks.shutil.disk_usage", return_value=usage):
+            check_disk_usage_task()
+
+        status = TaskExecutionStatus.objects.get(task_name=DISK_USAGE_TASK_NAME)
+        self.assertEqual(status.last_status, TaskExecutionStatus.STATUS_FAILURE)
+        self.assertIn("CRITICAL", status.last_error)

--- a/django/main/tests/test_views.py
+++ b/django/main/tests/test_views.py
@@ -10,6 +10,7 @@ from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from django.core.files.base import ContentFile
 from main.models import (
     HeatmapSnapshot,
     PageView,
@@ -218,6 +219,7 @@ class ViewsTest(TestCase):
             username="portfolio-admin",
             total=12,
             weeks_count=2,
+            fetched_at=timezone.now(),
             payload={
                 "username": "portfolio-admin",
                 "total": 12,
@@ -300,7 +302,8 @@ class ViewsTest(TestCase):
         self.assertEqual(payload["total"], 9)
         fetch_mock.assert_called_once_with()
 
-    def test_about_heatmap_data_shows_error_when_admin_github_token_missing(self):
+    @patch("main.views.get_configured_github_token", return_value=None)
+    def test_about_heatmap_data_shows_error_when_admin_github_token_missing(self, _token_mock):
         response = self.client.get(reverse("about_heatmap_data"))
         payload = response.json()
 
@@ -413,7 +416,7 @@ class ViewsTest(TestCase):
     def test_blog_detail_sanitizes_unsafe_image_attributes(self):
         markdown_file = SimpleUploadedFile(
             "unsafe-image-readme.md",
-            b"<img src='x' alt='preview' onerror='alert(1)'>",
+            b"<img src='https://raw.githubusercontent.com/user/repo/img.png' alt='preview' onerror='alert(1)'>",
             content_type="text/markdown",
         )
         project = Project.objects.create(
@@ -428,7 +431,7 @@ class ViewsTest(TestCase):
         response = self.client.get(reverse("blog_detail", args=[project.blog_url]))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<img")
-        self.assertContains(response, 'src="x"')
+        self.assertContains(response, 'src="https://raw.githubusercontent.com/user/repo/img.png"')
         self.assertContains(response, 'alt="preview"')
         self.assertNotContains(response, "onerror")
 
@@ -606,6 +609,42 @@ class ViewsTest(TestCase):
 
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, reverse("home"))
+
+    def test_blog_detail_strips_external_img_src(self):
+        project = Project.objects.create(
+            title="Img Test",
+            short_description="img",
+            date=datetime.date(2024, 1, 1),
+            blog=True,
+            blog_url="img-test-slug",
+            status="finished",
+        )
+        external_md = b'# Test\n\n![tracker](https://evil.com/pixel.gif)\n\n![github](https://raw.githubusercontent.com/user/repo/main/img.png)\n'
+        project.markdown_file.save("img-test-slug.md", ContentFile(external_md), save=True)
+
+        response = self.client.get(reverse("blog_detail", args=["img-test-slug"]))
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertNotIn("evil.com", content)
+        self.assertIn("raw.githubusercontent.com", content)
+
+    def test_about_shows_disk_info_for_staff(self):
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+        staff = User.objects.create_user("diskstaff", password="pass", is_staff=True)
+        self.client.force_login(staff)
+
+        response = self.client.get(reverse("about"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("disk_info", response.context)
+        disk = response.context["disk_info"]
+        self.assertIn("free_gb", disk)
+        self.assertIn("used_gb", disk)
+        self.assertIn("total_gb", disk)
+        self.assertIn("level", disk)
+        self.assertIn(disk["level"], ("ok", "warning", "critical"))
 
 
 class ErrorHandlersTest(TestCase):

--- a/django/main/views.py
+++ b/django/main/views.py
@@ -1,5 +1,6 @@
 import bleach
 import markdown
+import shutil
 from datetime import date, timedelta
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
@@ -21,6 +22,8 @@ from .heatmap import (
 from .markdown_sync import build_readme_url, get_repo_path
 from .models import Project, Tag, TaskExecutionLog, TaskExecutionStatus
 from .tasks import (
+    DISK_CRITICAL_GB,
+    DISK_WARNING_GB,
     REFRESH_HEATMAP_TASK_NAME,
     SYNC_MARKDOWNS_TASK_NAME,
     refresh_portfolio_heatmap_cache_task,
@@ -63,6 +66,25 @@ ALLOWED_MARKDOWN_ATTRIBUTES = {
     "span": ["class"],
 }
 ALLOWED_MARKDOWN_PROTOCOLS = ["http", "https", "mailto"]
+
+_GITHUB_IMG_PREFIXES = (
+    "https://github.com/",
+    "https://raw.githubusercontent.com/",
+    "https://camo.githubusercontent.com/",
+)
+
+
+def _clean_attributes(tag, name, value):
+    # First check if the attribute is in the allowlist for this tag
+    allowed_attrs = ALLOWED_MARKDOWN_ATTRIBUTES.get(tag, [])
+    if name not in allowed_attrs:
+        return False
+
+    # Special handling for img src: only allow GitHub domains
+    if tag == "img" and name == "src":
+        return any(value.startswith(p) for p in _GITHUB_IMG_PREFIXES)
+
+    return True
 
 
 def handler404(request, exception):
@@ -116,6 +138,7 @@ def about(request):
     if is_admin_user:
         context["scheduled_jobs"] = _get_scheduled_jobs_overview()
         context["executed_tasks"] = _get_executed_tasks()
+        context["disk_info"] = _get_disk_info()
 
     return render(request, "pages/about.html", context)
 
@@ -212,6 +235,29 @@ def _calculate_last_30_days_total(payload):
                 continue
 
     return total
+
+
+def _get_disk_info():
+    usage = shutil.disk_usage("/")
+    free_gb = round(usage.free / (1024 ** 3), 1)
+    used_gb = round(usage.used / (1024 ** 3), 1)
+    total_gb = round(usage.total / (1024 ** 3), 1)
+    free_pct = round((usage.free / usage.total) * 100, 1)
+
+    if free_gb < DISK_CRITICAL_GB:
+        level = "critical"
+    elif free_gb < DISK_WARNING_GB:
+        level = "warning"
+    else:
+        level = "ok"
+
+    return {
+        "free_gb": free_gb,
+        "used_gb": used_gb,
+        "total_gb": total_gb,
+        "free_pct": free_pct,
+        "level": level,
+    }
 
 
 def _get_scheduled_jobs_overview():
@@ -324,7 +370,7 @@ def _render_markdown_to_html(markdown_content):
     return bleach.clean(
         markdown_html,
         tags=ALLOWED_MARKDOWN_TAGS,
-        attributes=ALLOWED_MARKDOWN_ATTRIBUTES,
+        attributes=_clean_attributes,
         protocols=ALLOWED_MARKDOWN_PROTOCOLS,
         strip=True,
     )

--- a/django/main/views.py
+++ b/django/main/views.py
@@ -239,14 +239,15 @@ def _calculate_last_30_days_total(payload):
 
 def _get_disk_info():
     usage = shutil.disk_usage("/")
-    free_gb = round(usage.free / (1024 ** 3), 1)
+    free_raw_gb = usage.free / (1024 ** 3)
+    free_gb = round(free_raw_gb, 1)
     used_gb = round(usage.used / (1024 ** 3), 1)
     total_gb = round(usage.total / (1024 ** 3), 1)
     free_pct = round((usage.free / usage.total) * 100, 1)
 
-    if free_gb < DISK_CRITICAL_GB:
+    if free_raw_gb < DISK_CRITICAL_GB:
         level = "critical"
-    elif free_gb < DISK_WARNING_GB:
+    elif free_raw_gb < DISK_WARNING_GB:
         level = "warning"
     else:
         level = "ok"

--- a/docs/superpowers/plans/2026-05-14-codebase-audit.md
+++ b/docs/superpowers/plans/2026-05-14-codebase-audit.md
@@ -1,0 +1,1257 @@
+# Codebase Audit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix security issues, dead code, disk resource waste, and outdated dependencies identified in the codebase audit, plus add disk usage monitoring for the admin panel.
+
+**Architecture:** One branch (`audit/codebase-2026`), four categories as separate commits. No new models or migrations — disk monitoring reuses `TaskExecutionStatus`. Requests replaces urllib in markdown sync; bleach gets a custom attribute cleaner for img src.
+
+**Tech Stack:** Django 5.1, Celery, bleach, requests, shutil, Docker Compose, PostgreSQL, uv
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `django/config/celery.py` | Remove `debug_task` |
+| `django/config/settings.py` | Add `CELERY_TASK_IGNORE_RESULT`, remove whitenoise comment, add disk task to beat schedule |
+| `django/main/tasks.py` | Add `ignore_result=True` to `healthcheck_task`, add `check_disk_usage_task` |
+| `django/main/context_processors.py` | Fix `visitor_counter` — replace `get_instance()` with read-only query |
+| `django/main/markdown_sync.py` | Replace urllib with requests; remove `opener` param |
+| `django/main/models.py` | Add `post_delete`/`pre_save` signals on `Project` for media file cleanup |
+| `django/main/views.py` | Add `_clean_attributes` for img src filtering; update `bleach.clean()` call; add `_get_disk_info()`; pass `disk_info` to about context |
+| `django/main/templates/pages/about.html` | Add Disk Usage admin panel section |
+| `infra/Dockerfile` | `node:20-slim` → `node:22-slim` |
+| `infra/docker-compose.prod.yml` | `postgres:13` → `postgres:16` |
+| `.env.example` | Add `DJANGO_DEBUG` production warning comment |
+| `uv.lock` | Updated by `uv lock --upgrade-package` |
+| `django/main/tests/test_markdown_sync.py` | Update from opener-pattern to `patch('main.markdown_sync.requests.get', ...)` |
+| `django/main/tests/test_tasks.py` | Add test for `check_disk_usage_task` |
+| `django/main/tests/test_views.py` | Add tests for img src filter and disk panel |
+| `django/main/tests/test_models.py` | Add test for post_delete media cleanup |
+
+---
+
+## Task 1: Remove dead code — `debug_task` and whitenoise comment
+
+**Files:**
+- Modify: `django/config/celery.py`
+- Modify: `django/config/settings.py`
+
+- [ ] **Step 1: Delete `debug_task` from celery.py**
+
+  Open `django/config/celery.py`. The file currently ends with:
+  ```python
+  @app.task(bind=True)
+  def debug_task(self):
+      print(f"Request: {self.request!r}")
+  ```
+  Delete those four lines entirely. The file should now end at `app.autodiscover_tasks()`.
+
+- [ ] **Step 2: Remove commented whitenoise line from settings.py**
+
+  Open `django/config/settings.py`. Find and delete line 181:
+  ```python
+  # STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'  # Commented out as we're using Caddy for static files
+  ```
+  The active `STATICFILES_STORAGE` line on 182 stays untouched.
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 uv run python django/manage.py check
+  grep -r "debug_task\|whitenoise" django/config/
+  ```
+  Expected: `System check identified no issues`. The grep returns no matches.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add django/config/celery.py django/config/settings.py
+  git commit -m "chore: remove debug_task dead code and whitenoise dead comment"
+  ```
+
+---
+
+## Task 2: Disable Celery result backend writes
+
+**Files:**
+- Modify: `django/config/settings.py`
+- Modify: `django/main/tasks.py`
+
+- [ ] **Step 1: Write failing test**
+
+  Open `django/main/tests/test_tasks.py`. Add this import at the top alongside existing ones:
+  ```python
+  from main.tasks import healthcheck_task, DISK_USAGE_TASK_NAME
+  ```
+  Add this test class at the end of the file:
+  ```python
+  class TaskIgnoreResultTests(TestCase):
+      def test_healthcheck_task_has_ignore_result(self):
+          self.assertTrue(getattr(healthcheck_task, "ignore_result", False))
+  ```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_tasks.TaskIgnoreResultTests -v 2
+  ```
+  Expected: FAIL — `AssertionError: False is not true`
+
+- [ ] **Step 3: Add `CELERY_TASK_IGNORE_RESULT` to settings**
+
+  Open `django/config/settings.py`. Find the Celery block (starts with `CELERY_BROKER_URL`). Add one line directly after `CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True`:
+  ```python
+  CELERY_TASK_IGNORE_RESULT = True
+  ```
+
+- [ ] **Step 4: Add `ignore_result=True` to `healthcheck_task`**
+
+  Open `django/main/tasks.py`. Find:
+  ```python
+  @shared_task
+  def healthcheck_task():
+      return "ok"
+  ```
+  Replace with:
+  ```python
+  @shared_task(ignore_result=True)
+  def healthcheck_task():
+      return "ok"
+  ```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_tasks.TaskIgnoreResultTests -v 2
+  ```
+  Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add django/config/settings.py django/main/tasks.py django/main/tests/test_tasks.py
+  git commit -m "perf: disable celery result backend writes — results are never read"
+  ```
+
+---
+
+## Task 3: Fix `visitor_counter` context processor
+
+**Files:**
+- Modify: `django/main/context_processors.py`
+- Test: `django/main/tests/test_views.py` (run existing, no new test needed)
+
+- [ ] **Step 1: Run existing context processor tests first**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views -v 2
+  ```
+  Note which tests pass — all must pass after the change too.
+
+- [ ] **Step 2: Replace `visitor_counter` with read-only query**
+
+  Open `django/main/context_processors.py`. Find:
+  ```python
+  def visitor_counter(request):
+      """Expose the global visit counter to all templates.
+
+      Returns:
+          dict: Context with `visitor_count` key.
+      """
+      count = PageView.get_instance().count
+      return {"visitor_count": count}
+  ```
+  Replace with:
+  ```python
+  def visitor_counter(request):
+      instance = PageView.objects.filter(id=1).first()
+      return {"visitor_count": instance.count if instance else 0}
+  ```
+
+- [ ] **Step 3: Run tests to verify nothing broke**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views -v 2
+  ```
+  Expected: same tests pass as before.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add django/main/context_processors.py
+  git commit -m "refactor: replace get_or_create with read-only query in visitor_counter"
+  ```
+
+---
+
+## Task 4: Migrate `markdown_sync` from urllib to requests
+
+**Files:**
+- Modify: `django/main/markdown_sync.py`
+- Modify: `django/main/tests/test_markdown_sync.py`
+
+- [ ] **Step 1: Run existing markdown sync tests first to confirm baseline**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_markdown_sync -v 2
+  ```
+  All tests must pass before touching code.
+
+- [ ] **Step 2: Rewrite `_download_markdown` and remove urllib in `markdown_sync.py`**
+
+  Open `django/main/markdown_sync.py`. Replace the import block at the top:
+  ```python
+  # OLD — remove these three lines:
+  from urllib.error import HTTPError, URLError
+  from urllib.request import Request, urlopen
+  ```
+  Keep `from urllib.parse import urlparse` (still used by `_active_github_username` and `_parse_github_owner_repo`).
+
+  Add `import requests` after `import logging`.
+
+  The file's imports section should now read:
+  ```python
+  import logging
+  import requests
+  from pathlib import Path
+  from urllib.parse import urlparse
+
+  from django.core.files.base import ContentFile
+
+  from .models import PortfolioProfile
+  ```
+
+  Replace the entire `_download_markdown` function:
+  ```python
+  def _download_markdown(url, timeout=20):
+      try:
+          response = requests.get(
+              url,
+              headers={"User-Agent": "my-django-portfolio-markdown-sync/1.0"},
+              timeout=timeout,
+          )
+          response.raise_for_status()
+      except requests.exceptions.HTTPError as exc:
+          raise exc
+      except requests.exceptions.RequestException as exc:
+          raise OSError(str(exc)) from exc
+
+      content_length = response.headers.get("Content-Length")
+      if content_length is not None:
+          try:
+              parsed_length = int(content_length)
+          except (TypeError, ValueError):
+              parsed_length = None
+          if parsed_length is not None and parsed_length > MAX_MARKDOWN_SIZE_BYTES:
+              raise ValueError(
+                  f"Downloaded markdown exceeds size limit ({MAX_MARKDOWN_SIZE_BYTES} bytes)"
+              )
+
+      raw_bytes = response.content
+      if len(raw_bytes) > MAX_MARKDOWN_SIZE_BYTES:
+          raise ValueError(
+              f"Downloaded markdown exceeds size limit ({MAX_MARKDOWN_SIZE_BYTES} bytes)"
+          )
+
+      text = raw_bytes.decode("utf-8-sig")
+      if text.lstrip().lower().startswith("<!doctype html") or text.lstrip().lower().startswith("<html"):
+          raise ValueError("Downloaded content is HTML, expected Markdown")
+      return text
+  ```
+
+  Update `sync_project_markdown` signature — remove the `opener=urlopen` parameter. Change:
+  ```python
+  def sync_project_markdown(project, timeout=20, opener=urlopen):
+  ```
+  to:
+  ```python
+  def sync_project_markdown(project, timeout=20):
+  ```
+
+  Inside `sync_project_markdown`, change the call from:
+  ```python
+  markdown_text = _download_markdown(url, timeout=timeout, opener=opener)
+  ```
+  to:
+  ```python
+  markdown_text = _download_markdown(url, timeout=timeout)
+  ```
+
+  Change the `except` clause inside the `for url in candidate_urls` loop from:
+  ```python
+  except (HTTPError, URLError, UnicodeDecodeError, ValueError, OSError) as exc:
+  ```
+  to:
+  ```python
+  except (requests.exceptions.HTTPError, requests.exceptions.RequestException,
+          UnicodeDecodeError, ValueError, OSError) as exc:
+  ```
+
+- [ ] **Step 3: Update `test_markdown_sync.py` to use `requests.get` mocking**
+
+  Open `django/main/tests/test_markdown_sync.py`. Replace the entire file content:
+
+  ```python
+  import datetime
+  import shutil
+  import tempfile
+  from unittest.mock import MagicMock, patch
+
+  import requests
+
+  from django.core.files.base import ContentFile
+  from django.test import TestCase, override_settings
+
+  from main.markdown_sync import sync_project_markdown
+  from main.models import PortfolioProfile, Project
+
+
+  def _make_mock_response(content: bytes, status_code: int = 200) -> MagicMock:
+      resp = MagicMock()
+      resp.status_code = status_code
+      resp.content = content
+      resp.headers = {}
+      if status_code >= 400:
+          resp.raise_for_status.side_effect = requests.exceptions.HTTPError(
+              response=resp
+          )
+      else:
+          resp.raise_for_status.return_value = None
+      return resp
+
+
+  class MarkdownSyncTests(TestCase):
+      @classmethod
+      def setUpClass(cls):
+          super().setUpClass()
+          cls._media_root = tempfile.mkdtemp(prefix="markdown-sync-tests-")
+          cls._override = override_settings(MEDIA_ROOT=cls._media_root)
+          cls._override.enable()
+
+      @classmethod
+      def tearDownClass(cls):
+          cls._override.disable()
+          shutil.rmtree(cls._media_root, ignore_errors=True)
+          super().tearDownClass()
+
+      def setUp(self):
+          profile = PortfolioProfile.objects.get(is_active=True)
+          profile.github_url = "https://github.com/test-user"
+          profile.save(update_fields=["github_url"])
+
+      def test_sync_project_markdown_replaces_file_on_success(self):
+          project = Project.objects.create(
+              title="Sync Success",
+              short_description="sync test",
+              date=datetime.date(2025, 1, 1),
+              blog=True,
+              blog_url="sync-success",
+              github_url="https://github.com/example/sync-success",
+              status="finished",
+          )
+          project.markdown_file.save("sync-success.md", ContentFile(b"# Old"), save=True)
+
+          with patch(
+              "main.markdown_sync.requests.get",
+              return_value=_make_mock_response(b"# New Content\n\nUpdated."),
+          ):
+              result = sync_project_markdown(project)
+
+          self.assertTrue(result["updated"])
+          project.refresh_from_db()
+          project.markdown_file.open("rb")
+          self.assertEqual(
+              project.markdown_file.read().decode("utf-8"), "# New Content\n\nUpdated."
+          )
+          project.markdown_file.close()
+
+      def test_sync_project_markdown_keeps_old_file_on_failure(self):
+          project = Project.objects.create(
+              title="Sync Failure",
+              short_description="sync test",
+              date=datetime.date(2025, 1, 1),
+              blog=True,
+              blog_url="sync-failure",
+              github_url="https://github.com/example/sync-failure",
+              status="finished",
+          )
+          project.markdown_file.save("sync-failure.md", ContentFile(b"# Old"), save=True)
+          old_name = project.markdown_file.name
+
+          with patch(
+              "main.markdown_sync.requests.get",
+              side_effect=requests.exceptions.ConnectionError("network down"),
+          ):
+              result = sync_project_markdown(project)
+
+          self.assertFalse(result["updated"])
+          project.refresh_from_db()
+          self.assertEqual(project.markdown_file.name, old_name)
+          project.markdown_file.open("rb")
+          self.assertEqual(project.markdown_file.read().decode("utf-8"), "# Old")
+          project.markdown_file.close()
+
+      def test_sync_project_markdown_rejects_oversized_download(self):
+          project = Project.objects.create(
+              title="Sync Too Large",
+              short_description="sync test",
+              date=datetime.date(2025, 1, 1),
+              blog=True,
+              blog_url="sync-too-large",
+              github_url="https://github.com/example/sync-too-large",
+              status="finished",
+          )
+          project.markdown_file.save("sync-too-large.md", ContentFile(b"# Old"), save=True)
+          old_name = project.markdown_file.name
+          oversized_payload = b"a" * (10 * 1024 * 1024 + 1)
+
+          with patch(
+              "main.markdown_sync.requests.get",
+              return_value=_make_mock_response(oversized_payload),
+          ):
+              result = sync_project_markdown(project)
+
+          self.assertFalse(result["updated"])
+          self.assertEqual(result["reason"], "download_failed")
+          self.assertIn("exceeds size limit", result["error"])
+
+          project.refresh_from_db()
+          self.assertEqual(project.markdown_file.name, old_name)
+          project.markdown_file.open("rb")
+          self.assertEqual(project.markdown_file.read().decode("utf-8"), "# Old")
+          project.markdown_file.close()
+  ```
+
+- [ ] **Step 4: Run updated tests to verify they pass**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_markdown_sync -v 2
+  ```
+  Expected: all three tests PASS.
+
+- [ ] **Step 5: Verify no urllib imports remain in markdown_sync**
+
+  ```bash
+  grep "urllib.request\|urllib.error\|urlopen\|HTTPError\|URLError" django/main/markdown_sync.py
+  ```
+  Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add django/main/markdown_sync.py django/main/tests/test_markdown_sync.py
+  git commit -m "refactor: migrate markdown_sync HTTP client from urllib to requests"
+  ```
+
+---
+
+## Task 5: Auto-delete media files when Project is deleted or field cleared
+
+**Files:**
+- Modify: `django/main/models.py`
+- Test: `django/main/tests/test_models.py`
+
+- [ ] **Step 1: Write failing tests**
+
+  Open `django/main/tests/test_models.py`. Add these imports at the top if not present:
+  ```python
+  import datetime
+  import shutil
+  import tempfile
+  from django.core.files.base import ContentFile
+  from django.test import TestCase, override_settings
+  ```
+
+  Add this test class at the end of the file:
+  ```python
+  class ProjectMediaCleanupTests(TestCase):
+      @classmethod
+      def setUpClass(cls):
+          super().setUpClass()
+          cls._media_root = tempfile.mkdtemp(prefix="project-media-tests-")
+          cls._override = override_settings(MEDIA_ROOT=cls._media_root)
+          cls._override.enable()
+
+      @classmethod
+      def tearDownClass(cls):
+          cls._override.disable()
+          shutil.rmtree(cls._media_root, ignore_errors=True)
+          super().tearDownClass()
+
+      def _make_project_with_thumbnail(self):
+          from main.models import Project
+          project = Project.objects.create(
+              title="Media Test",
+              short_description="test",
+              date=datetime.date(2025, 1, 1),
+              status="finished",
+          )
+          project.thumbnail.save("thumb.png", ContentFile(b"fake-png"), save=True)
+          return project
+
+      def test_thumbnail_deleted_when_project_deleted(self):
+          from main.models import Project
+          project = self._make_project_with_thumbnail()
+          storage = project.thumbnail.storage
+          thumb_name = project.thumbnail.name
+          self.assertTrue(storage.exists(thumb_name))
+
+          project.delete()
+
+          self.assertFalse(storage.exists(thumb_name))
+
+      def test_old_thumbnail_deleted_when_replaced(self):
+          from main.models import Project
+          project = self._make_project_with_thumbnail()
+          storage = project.thumbnail.storage
+          old_name = project.thumbnail.name
+          self.assertTrue(storage.exists(old_name))
+
+          project.thumbnail.save("thumb_new.png", ContentFile(b"new-fake-png"), save=True)
+
+          self.assertFalse(storage.exists(old_name))
+  ```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_models.ProjectMediaCleanupTests -v 2
+  ```
+  Expected: FAIL — the files still exist after delete/replace.
+
+- [ ] **Step 3: Add signal handlers to `models.py`**
+
+  Open `django/main/models.py`. Add this import at the top:
+  ```python
+  from django.db.models.signals import post_delete, pre_save
+  from django.dispatch import receiver
+  ```
+
+  Add these signal handlers at the end of the file (after all model definitions):
+  ```python
+  def _delete_file_field(field):
+      """Delete the file associated with a FileField/ImageField if it exists."""
+      if field and field.name:
+          storage = field.storage
+          if storage.exists(field.name):
+              storage.delete(field.name)
+
+
+  @receiver(post_delete, sender=Project)
+  def _project_post_delete(sender, instance, **kwargs):
+      _delete_file_field(instance.thumbnail)
+      _delete_file_field(instance.markdown_file)
+
+
+  @receiver(pre_save, sender=Project)
+  def _project_pre_save(sender, instance, **kwargs):
+      if not instance.pk:
+          return
+      try:
+          old = Project.objects.get(pk=instance.pk)
+      except Project.DoesNotExist:
+          return
+      if old.thumbnail and old.thumbnail != instance.thumbnail:
+          _delete_file_field(old.thumbnail)
+      if old.markdown_file and old.markdown_file != instance.markdown_file:
+          _delete_file_field(old.markdown_file)
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_models.ProjectMediaCleanupTests -v 2
+  ```
+  Expected: PASS.
+
+- [ ] **Step 5: Run full suite to confirm no regression**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main -v 2
+  ```
+  Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add django/main/models.py django/main/tests/test_models.py
+  git commit -m "feat: auto-delete media files when Project is deleted or thumbnail replaced"
+  ```
+
+---
+
+## Task 6: Restrict `img src` in markdown rendering to GitHub domains
+
+**Files:**
+- Modify: `django/main/views.py`
+- Test: `django/main/tests/test_views.py`
+
+- [ ] **Step 1: Write failing test**
+
+  Open `django/main/tests/test_views.py`. Find the `ViewsTest` class. Add this test method to it:
+  ```python
+  def test_blog_detail_strips_external_img_src(self):
+      import shutil, tempfile
+      from django.core.files.base import ContentFile
+      from django.test import override_settings
+
+      media_root = tempfile.mkdtemp(prefix="blog-img-test-")
+      try:
+          with override_settings(MEDIA_ROOT=media_root):
+              project = Project.objects.create(
+                  title="Img Test",
+                  short_description="img",
+                  date=datetime.date(2024, 1, 1),
+                  blog=True,
+                  blog_url="img-test-slug",
+                  status="finished",
+              )
+              external_md = b'# Test\n\n![tracker](https://evil.com/pixel.gif)\n\n![github](https://raw.githubusercontent.com/user/repo/main/img.png)\n'
+              project.markdown_file.save("img-test-slug.md", ContentFile(external_md), save=True)
+
+              response = self.client.get(reverse("blog_detail", args=["img-test-slug"]))
+
+              self.assertEqual(response.status_code, 200)
+              content = response.content.decode()
+              self.assertNotIn("evil.com", content)
+              self.assertIn("raw.githubusercontent.com", content)
+      finally:
+          shutil.rmtree(media_root, ignore_errors=True)
+  ```
+
+- [ ] **Step 2: Run to verify it fails**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views.ViewsTest.test_blog_detail_strips_external_img_src -v 2
+  ```
+  Expected: FAIL — `evil.com` appears in rendered content.
+
+- [ ] **Step 3: Add `_clean_attributes` and update `bleach.clean()` in `views.py`**
+
+  Open `django/main/views.py`. Find the constants block near the top (after imports). After `ALLOWED_MARKDOWN_PROTOCOLS`, add:
+
+  ```python
+  _GITHUB_IMG_PREFIXES = (
+      "https://github.com/",
+      "https://raw.githubusercontent.com/",
+      "https://camo.githubusercontent.com/",
+  )
+
+
+  def _clean_attributes(tag, name, value):
+      if tag == "img" and name == "src":
+          return any(value.startswith(p) for p in _GITHUB_IMG_PREFIXES)
+      return True
+  ```
+
+  Now find the `blog_detail` view. Inside it, find the `bleach.clean()` call. It currently looks like:
+  ```python
+  bleach.clean(
+      html_content,
+      tags=ALLOWED_MARKDOWN_TAGS,
+      attributes=ALLOWED_MARKDOWN_ATTRIBUTES,
+      protocols=ALLOWED_MARKDOWN_PROTOCOLS,
+      strip=True,
+  )
+  ```
+  Change `attributes=ALLOWED_MARKDOWN_ATTRIBUTES` to `attributes=_clean_attributes`:
+  ```python
+  bleach.clean(
+      html_content,
+      tags=ALLOWED_MARKDOWN_TAGS,
+      attributes=_clean_attributes,
+      protocols=ALLOWED_MARKDOWN_PROTOCOLS,
+      strip=True,
+  )
+  ```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views.ViewsTest.test_blog_detail_strips_external_img_src -v 2
+  ```
+  Expected: PASS.
+
+- [ ] **Step 5: Run full view tests**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views -v 2
+  ```
+  Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add django/main/views.py django/main/tests/test_views.py
+  git commit -m "security: restrict img src in markdown to github.com domains only"
+  ```
+
+---
+
+## Task 7: Add `.env.example` production warning
+
+**Files:**
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add warning comment to `DJANGO_DEBUG` line**
+
+  Open `.env.example`. Find:
+  ```
+  DJANGO_DEBUG=True
+  ```
+  Replace with:
+  ```
+  DJANGO_DEBUG=True  # DEVELOPMENT ONLY — set to False in production
+  ```
+
+- [ ] **Step 2: Verify**
+
+  ```bash
+  grep "DJANGO_DEBUG" .env.example
+  ```
+  Expected: `DJANGO_DEBUG=True  # DEVELOPMENT ONLY — set to False in production`
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add .env.example
+  git commit -m "docs: warn against copying DJANGO_DEBUG=True to production"
+  ```
+
+---
+
+## Task 8: Disk usage monitoring Celery task
+
+**Files:**
+- Modify: `django/main/tasks.py`
+- Modify: `django/config/settings.py`
+- Test: `django/main/tests/test_tasks.py`
+
+- [ ] **Step 1: Write failing test**
+
+  Open `django/main/tests/test_tasks.py`. Add this import at the top:
+  ```python
+  import shutil
+  from unittest.mock import patch
+  from main.tasks import check_disk_usage_task, DISK_USAGE_TASK_NAME
+  ```
+
+  Add this test class at the end of the file:
+  ```python
+  class DiskUsageTaskTests(TestCase):
+      def _make_usage(self, total_gb, used_gb):
+          total = int(total_gb * 1024 ** 3)
+          used = int(used_gb * 1024 ** 3)
+          free = total - used
+          return shutil.disk_usage.__class__.__mro__  # placeholder — see below
+  ```
+
+  Actually replace the entire class with:
+  ```python
+  class DiskUsageTaskTests(TestCase):
+      def _fake_usage(self, total_gb, free_gb):
+          total = int(total_gb * 1024 ** 3)
+          free = int(free_gb * 1024 ** 3)
+          used = total - free
+          import collections
+          DiskUsage = collections.namedtuple("DiskUsage", ["total", "used", "free"])
+          return DiskUsage(total=total, used=used, free=free)
+
+      def test_disk_task_success_when_ample_space(self):
+          usage = self._fake_usage(total_gb=10.0, free_gb=5.0)
+          with patch("main.tasks.shutil.disk_usage", return_value=usage):
+              check_disk_usage_task()
+
+          status = TaskExecutionStatus.objects.get(task_name=DISK_USAGE_TASK_NAME)
+          self.assertEqual(status.last_status, TaskExecutionStatus.STATUS_SUCCESS)
+          self.assertEqual(status.last_error, "")
+
+      def test_disk_task_partial_when_below_2gb(self):
+          usage = self._fake_usage(total_gb=10.0, free_gb=1.5)
+          with patch("main.tasks.shutil.disk_usage", return_value=usage):
+              check_disk_usage_task()
+
+          status = TaskExecutionStatus.objects.get(task_name=DISK_USAGE_TASK_NAME)
+          self.assertEqual(status.last_status, TaskExecutionStatus.STATUS_PARTIAL_SUCCESS)
+          self.assertIn("1.5", status.last_error)
+
+      def test_disk_task_failure_when_below_1gb(self):
+          usage = self._fake_usage(total_gb=10.0, free_gb=0.8)
+          with patch("main.tasks.shutil.disk_usage", return_value=usage):
+              check_disk_usage_task()
+
+          status = TaskExecutionStatus.objects.get(task_name=DISK_USAGE_TASK_NAME)
+          self.assertEqual(status.last_status, TaskExecutionStatus.STATUS_FAILURE)
+          self.assertIn("CRITICAL", status.last_error)
+  ```
+
+- [ ] **Step 2: Run to verify they fail**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_tasks.DiskUsageTaskTests -v 2
+  ```
+  Expected: ImportError or AttributeError — `check_disk_usage_task` doesn't exist yet.
+
+- [ ] **Step 3: Add `check_disk_usage_task` to `tasks.py`**
+
+  Open `django/main/tasks.py`. Add `import shutil` to the imports at the top.
+
+  Add the constant after the existing task name constants:
+  ```python
+  DISK_USAGE_TASK_NAME = "main.check_disk_usage_task"
+  ```
+
+  Add the task function after the existing task functions (before `_maybe_schedule_next_refresh`):
+  ```python
+  @shared_task(ignore_result=True)
+  def check_disk_usage_task():
+      usage = shutil.disk_usage("/")
+      free_gb = usage.free / (1024 ** 3)
+
+      status, _ = TaskExecutionStatus.objects.get_or_create(task_name=DISK_USAGE_TASK_NAME)
+      status.last_run_at = timezone.now()
+      status.last_total = 1
+
+      if free_gb < 1.0:
+          logger.critical("DISK CRITICAL: only %.1f GB free on /", free_gb)
+          status.last_status = TaskExecutionStatus.STATUS_FAILURE
+          status.last_updated = 0
+          status.last_failed = 1
+          status.last_error = f"CRITICAL: {free_gb:.1f} GB free (below 1 GB threshold)"
+          status.last_success_at = None
+          status.last_failure_at = timezone.now()
+      elif free_gb < 2.0:
+          logger.warning("DISK WARNING: only %.1f GB free on /", free_gb)
+          status.last_status = TaskExecutionStatus.STATUS_PARTIAL_SUCCESS
+          status.last_updated = 0
+          status.last_failed = 1
+          status.last_error = f"WARNING: {free_gb:.1f} GB free (below 2 GB threshold)"
+          status.last_success_at = None
+          status.last_failure_at = timezone.now()
+      else:
+          logger.info("DISK OK: %.1f GB free on /", free_gb)
+          status.last_status = TaskExecutionStatus.STATUS_SUCCESS
+          status.last_updated = 1
+          status.last_failed = 0
+          status.last_error = ""
+          status.last_success_at = timezone.now()
+          status.last_failure_at = None
+
+      status.save(
+          update_fields=[
+              "last_status",
+              "last_run_at",
+              "last_success_at",
+              "last_failure_at",
+              "last_total",
+              "last_updated",
+              "last_failed",
+              "last_error",
+          ]
+      )
+      _log_task_execution(status)
+  ```
+
+- [ ] **Step 4: Register task in beat schedule**
+
+  Open `django/config/settings.py`. Find `CELERY_BEAT_SCHEDULE`. Add a new entry:
+  ```python
+  "check-disk-usage-daily": {
+      "task": "main.tasks.check_disk_usage_task",
+      "schedule": crontab(hour=6, minute=0),
+  },
+  ```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_tasks.DiskUsageTaskTests -v 2
+  ```
+  Expected: all three PASS.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add django/main/tasks.py django/config/settings.py django/main/tests/test_tasks.py
+  git commit -m "feat: add daily disk usage monitoring task with warning/critical thresholds"
+  ```
+
+---
+
+## Task 9: Disk usage panel on admin about page
+
+**Files:**
+- Modify: `django/main/views.py`
+- Modify: `django/main/templates/pages/about.html`
+- Test: `django/main/tests/test_views.py`
+
+- [ ] **Step 1: Write failing test**
+
+  Open `django/main/tests/test_views.py`. Find the `ViewsTest` class. Add:
+  ```python
+  def test_about_shows_disk_info_for_staff(self):
+      from django.contrib.auth import get_user_model
+      User = get_user_model()
+      staff = User.objects.create_user("diskstaff", password="pass", is_staff=True)
+      self.client.force_login(staff)
+
+      response = self.client.get(reverse("about"))
+
+      self.assertEqual(response.status_code, 200)
+      self.assertIn("disk_info", response.context)
+      disk = response.context["disk_info"]
+      self.assertIn("free_gb", disk)
+      self.assertIn("used_gb", disk)
+      self.assertIn("total_gb", disk)
+      self.assertIn("level", disk)
+      self.assertIn(disk["level"], ("ok", "warning", "critical"))
+  ```
+
+- [ ] **Step 2: Run to verify it fails**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views.ViewsTest.test_about_shows_disk_info_for_staff -v 2
+  ```
+  Expected: FAIL — `disk_info` not in context.
+
+- [ ] **Step 3: Add `_get_disk_info()` helper and inject into about view**
+
+  Open `django/main/views.py`. Add `import shutil` to the imports at the top.
+
+  Add this helper function near the other private helpers (`_get_scheduled_jobs_overview`, `_get_executed_tasks`):
+  ```python
+  def _get_disk_info():
+      usage = shutil.disk_usage("/")
+      free_gb = round(usage.free / (1024 ** 3), 1)
+      used_gb = round(usage.used / (1024 ** 3), 1)
+      total_gb = round(usage.total / (1024 ** 3), 1)
+      free_pct = round((usage.free / usage.total) * 100, 1)
+
+      if free_gb < 1.0:
+          level = "critical"
+      elif free_gb < 2.0:
+          level = "warning"
+      else:
+          level = "ok"
+
+      return {
+          "free_gb": free_gb,
+          "used_gb": used_gb,
+          "total_gb": total_gb,
+          "free_pct": free_pct,
+          "level": level,
+      }
+  ```
+
+  In the `about` view, find the `if is_admin_user:` block:
+  ```python
+  if is_admin_user:
+      context["scheduled_jobs"] = _get_scheduled_jobs_overview()
+      context["executed_tasks"] = _get_executed_tasks()
+  ```
+  Add one line:
+  ```python
+  if is_admin_user:
+      context["scheduled_jobs"] = _get_scheduled_jobs_overview()
+      context["executed_tasks"] = _get_executed_tasks()
+      context["disk_info"] = _get_disk_info()
+  ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views.ViewsTest.test_about_shows_disk_info_for_staff -v 2
+  ```
+  Expected: PASS.
+
+- [ ] **Step 5: Add Disk Usage panel to `about.html`**
+
+  Open `django/main/templates/pages/about.html`. Find the line:
+  ```html
+  {% if request.user.is_authenticated and request.user.is_staff %}
+  <section class="mt-6 rounded-2xl border border-base-300 bg-base-200 shadow-sm">
+      <div class="p-4 sm:p-6">
+          <div class="flex items-center justify-between">
+              <h2 class="text-xl font-semibold text-primary">Scheduled Jobs</h2>
+  ```
+
+  Insert the following block **before** that `{% if %}` tag (so it appears before the Scheduled Jobs section, still inside the admin guard — move it inside the existing admin `{% if %}` block):
+
+  Actually, the disk panel goes **inside** the existing `{% if request.user.is_authenticated and request.user.is_staff %}` block, **before** the Scheduled Jobs section. Find:
+  ```html
+      {% if request.user.is_authenticated and request.user.is_staff %}
+      <section class="mt-6 rounded-2xl border border-base-300 bg-base-200 shadow-sm">
+          <div class="p-4 sm:p-6">
+              <div class="flex items-center justify-between">
+                  <h2 class="text-xl font-semibold text-primary">Scheduled Jobs</h2>
+  ```
+
+  Insert this block between the `{% if request.user.is_authenticated and request.user.is_staff %}` line and the Scheduled Jobs `<section>`:
+  ```html
+      {% if disk_info %}
+      <section class="mt-6 rounded-2xl border border-base-300 bg-base-200 shadow-sm">
+          <div class="p-4 sm:p-6">
+              <div class="flex items-center justify-between">
+                  <h2 class="text-xl font-semibold text-primary">Disk Usage</h2>
+                  <span class="badge badge-outline badge-sm">Admin</span>
+              </div>
+              <div class="mt-4 grid gap-3 sm:grid-cols-3">
+                  <article class="rounded-xl border border-base-300 bg-base-100 p-4">
+                      <p class="text-xs font-medium uppercase tracking-wide text-base-content/80">Free</p>
+                      <p class="mt-1 text-lg font-semibold {% if disk_info.level == 'critical' %}text-error{% elif disk_info.level == 'warning' %}text-warning{% else %}text-success{% endif %}">
+                          {{ disk_info.free_gb }} GB ({{ disk_info.free_pct }}%)
+                      </p>
+                  </article>
+                  <article class="rounded-xl border border-base-300 bg-base-100 p-4">
+                      <p class="text-xs font-medium uppercase tracking-wide text-base-content/80">Used</p>
+                      <p class="mt-1 text-lg font-semibold">{{ disk_info.used_gb }} GB</p>
+                  </article>
+                  <article class="rounded-xl border border-base-300 bg-base-100 p-4">
+                      <p class="text-xs font-medium uppercase tracking-wide text-base-content/80">Total</p>
+                      <p class="mt-1 text-lg font-semibold">{{ disk_info.total_gb }} GB</p>
+                  </article>
+              </div>
+          </div>
+      </section>
+      {% endif %}
+  ```
+
+- [ ] **Step 6: Run full view tests**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test main.tests.test_views -v 2
+  ```
+  Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add django/main/views.py django/main/templates/pages/about.html django/main/tests/test_views.py
+  git commit -m "feat: add disk usage panel to about page admin section"
+  ```
+
+---
+
+## Task 10: Upgrade Node 20 → 22 in Dockerfile
+
+**Files:**
+- Modify: `infra/Dockerfile`
+
+- [ ] **Step 1: Change the Node base image**
+
+  Open `infra/Dockerfile`. Find line 2:
+  ```dockerfile
+  FROM node:20-slim AS css-builder
+  ```
+  Change to:
+  ```dockerfile
+  FROM node:22-slim AS css-builder
+  ```
+
+- [ ] **Step 2: Verify CSS build still works**
+
+  ```bash
+  npm run build:css:prod
+  ```
+  Expected: CSS file generated at `django/main/static/css/style.css` with no errors.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add infra/Dockerfile
+  git commit -m "chore: upgrade Node 20 → 22 in Dockerfile (Node 20 EOL Apr 2026)"
+  ```
+
+---
+
+## Task 11: Update Python package versions
+
+**Files:**
+- Modify: `uv.lock` (generated automatically)
+
+- [ ] **Step 1: Upgrade patch-safe packages**
+
+  ```bash
+  uv lock --upgrade-package pillow --upgrade-package requests --upgrade-package bleach --upgrade-package django
+  ```
+  This updates `uv.lock` to the latest patch releases within the pinned major versions. Check what changed:
+  ```bash
+  git diff uv.lock | grep "^[-+].*version" | head -20
+  ```
+
+- [ ] **Step 2: Re-sync the virtual environment**
+
+  ```bash
+  uv sync --extra dev
+  ```
+
+- [ ] **Step 3: Run full verification**
+
+  ```bash
+  make verify
+  ```
+  Expected: all checks pass. If any test fails due to a package API change, investigate and fix before committing.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add uv.lock
+  git commit -m "chore: update python packages to latest patch versions"
+  ```
+
+---
+
+## Task 12: Upgrade PostgreSQL 13 → 16
+
+**Files:**
+- Modify: `infra/docker-compose.prod.yml`
+
+> **Note:** Steps 1-3 are manual production operations performed on the DigitalOcean droplet, not code changes. Step 4 is the code change.
+
+- [ ] **Step 1: Dump the current database (on the droplet)**
+
+  SSH into the droplet, then:
+  ```bash
+  cd ~/my_django_portfolio
+
+  # Get the running db container name
+  docker ps --filter "name=db" --format "{{.Names}}"
+  # Example output: my_django_portfolio-db-1
+
+  # Dump the database
+  docker exec my_django_portfolio-db-1 \
+    pg_dump -U $DOCKER_DB_USER $DOCKER_DB_NAME \
+    > ~/pg_backup_$(date +%F).sql
+
+  # Verify the dump is non-empty
+  wc -l ~/pg_backup_$(date +%F).sql
+  ```
+  Expected: thousands of lines. If the file is empty or errors out, stop and investigate before proceeding.
+
+- [ ] **Step 2: Update `docker-compose.prod.yml` locally**
+
+  Open `infra/docker-compose.prod.yml`. Find:
+  ```yaml
+  db:
+    image: postgres:13
+  ```
+  Change to:
+  ```yaml
+  db:
+    image: postgres:16
+  ```
+
+- [ ] **Step 3: Commit the compose change**
+
+  ```bash
+  git add infra/docker-compose.prod.yml
+  git commit -m "chore: upgrade PostgreSQL 13 → 16 (13 EOL Nov 2025)"
+  ```
+
+- [ ] **Step 4: Deploy and perform the data migration (on the droplet)**
+
+  After the commit is on `main` and the new image is pushed (CI/CD runs), SSH into the droplet:
+  ```bash
+  cd ~/my_django_portfolio
+
+  # Stop all services
+  docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml down
+
+  # Remove the old postgres data volume (required — PG13 data is incompatible with PG16)
+  docker volume rm my_django_portfolio_postgres_data
+
+  # Pull and start the new stack (PG16 initializes fresh)
+  docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml pull
+  docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml up -d
+
+  # Wait ~10 seconds for db to be healthy, then check
+  sleep 10
+  docker compose --env-file .env -p my_django_portfolio -f infra/docker-compose.prod.yml ps
+  ```
+
+- [ ] **Step 5: Restore the database dump (on the droplet)**
+
+  ```bash
+  # Get new db container name
+  docker ps --filter "name=db" --format "{{.Names}}"
+
+  # Restore — substitute the actual date in the filename
+  docker exec -i my_django_portfolio-db-1 \
+    psql -U $DOCKER_DB_USER $DOCKER_DB_NAME \
+    < ~/pg_backup_2026-05-14.sql
+
+  # Verify by checking table count
+  docker exec my_django_portfolio-db-1 \
+    psql -U $DOCKER_DB_USER $DOCKER_DB_NAME \
+    -c "\dt" | wc -l
+  ```
+  Expected: 15+ tables listed.
+
+- [ ] **Step 6: Verify the site works**
+
+  Open the site in a browser. Check:
+  - Home page loads
+  - Projects page loads
+  - Admin `/admin/` accessible
+
+  ```bash
+  make prod-status
+  ```
+  All services should show `Up`.
+
+---
+
+## Final verification
+
+- [ ] **Run full suite locally**
+
+  ```bash
+  make verify
+  ```
+  Expected: all steps pass with no errors.
+
+- [ ] **Run all tests individually to confirm no regressions**
+
+  ```bash
+  SECRET_KEY=test DJANGO_DEBUG=True ALLOWED_HOSTS=localhost,127.0.0.1 \
+    uv run python django/manage.py test -v 2
+  ```
+  Expected: all tests pass.
+
+---
+
+## Self-review notes
+
+**Spec coverage check:**
+- ✅ 1a Celery ignore_result → Task 2
+- ✅ 1b Media file cleanup → Task 5
+- ✅ 1c Disk monitoring task + about panel → Tasks 8, 9
+- ✅ 2a img src filter → Task 6
+- ✅ 2b .env.example warning → Task 7
+- ✅ 3a debug_task removed → Task 1
+- ✅ 3b whitenoise comment removed → Task 1
+- ✅ 3c urllib → requests → Task 4
+- ✅ 3d visitor_counter read-only → Task 3
+- ✅ 4a postgres:13 → 16 → Task 12
+- ✅ 4b Python packages → Task 11
+- ✅ 4c Node 20 → 22 → Task 10

--- a/docs/superpowers/specs/2026-05-14-codebase-audit-design.md
+++ b/docs/superpowers/specs/2026-05-14-codebase-audit-design.md
@@ -1,0 +1,170 @@
+# Codebase Audit — Design Spec
+
+**Date:** 2026-05-14
+**Branch:** `audit/codebase-2026`
+**Approach:** One branch, one PR, categories as separate commits.
+
+---
+
+## Scope
+
+Four audit categories, each producing immediate fixes:
+
+1. Disk / Resources
+2. Security
+3. Dead code / Quality
+4. Old packages / Upgrade
+
+Plus one new feature: disk usage monitoring.
+
+---
+
+## Category 1 — Disk / Resources
+
+### 1a. Disable Celery result backend writes
+
+**Finding:** `CELERY_RESULT_BACKEND` is configured (redis:6379/1) but `AsyncResult` is never called anywhere in the codebase. Task results are written to Redis on every run and expire after the default 1-day TTL — wasted writes.
+
+**Fix:** Add `CELERY_TASK_IGNORE_RESULT = True` to `django/config/settings.py`. Decorate `healthcheck_task` and all `@shared_task` functions with `ignore_result=True` explicitly. This stops Redis writes for task results entirely.
+
+### 1b. Auto-delete media files on Project delete
+
+**Finding:** When a `Project` is deleted (or its `thumbnail`/`markdown_file` field is cleared), the file on disk is not removed. `media/thumbnails/` and `media/blog_markdown/` grow without bound.
+
+**Fix:** Add a `post_delete` signal handler on `Project` in `django/main/models.py` that calls `.delete(save=False)` on `thumbnail` and `markdown_file` if they exist. Also add a `pre_save` signal to detect field changes and delete the old file when a field is overwritten.
+
+### 1c. Disk usage monitoring (new feature)
+
+**New Celery beat task:** `check_disk_usage_task` runs daily at 06:00 UTC. Uses `shutil.disk_usage('/')` to check available bytes. Logs a `WARNING` if free space is below 2 GB, `CRITICAL` if below 1 GB. Stores result in `TaskExecutionStatus` using `task_name = "main.check_disk_usage_task"` — same pattern as existing tasks.
+
+**About page admin panel:** Add a "Disk Usage" section visible to staff on `/about/`. Shows total, used, free (in GB) and a coloured badge (green / yellow / red). Data comes from `TaskExecutionStatus` for the disk task — no extra DB model needed.
+
+---
+
+## Category 2 — Security
+
+### 2a. Restrict `img src` in markdown rendering
+
+**Finding:** `ALLOWED_MARKDOWN_ATTRIBUTES` passes `img src` with any URL. Images from external domains load in the visitor's browser, leaking their IP (tracking pixels). While markdown content is controlled by the repo owner (GitHub README sync), the rendered HTML is still served to every visitor.
+
+**Fix:** Replace the static `ALLOWED_MARKDOWN_ATTRIBUTES` dict with a custom bleach attribute cleaner function. The cleaner allows `img src` only when the URL starts with `https://github.com/` or `https://raw.githubusercontent.com/`. All other `img src` values are stripped. Other attributes keep their current rules.
+
+Implementation in `django/main/views.py`:
+
+```python
+GITHUB_IMG_PREFIXES = (
+    "https://github.com/",
+    "https://raw.githubusercontent.com/",
+    "https://camo.githubusercontent.com/",
+)
+
+def _clean_attributes(tag, name, value):
+    if tag == "img" and name == "src":
+        if not any(value.startswith(p) for p in GITHUB_IMG_PREFIXES):
+            return False
+    return True
+```
+
+Pass `_clean_attributes` as the `attributes` argument to `bleach.clean()`.
+
+### 2b. `.env.example` warning comment
+
+**Finding:** `.env.example` has `DJANGO_DEBUG=True` with no warning. A careless copy to production would expose debug info.
+
+**Fix:** Add an inline comment: `DJANGO_DEBUG=True  # DEVELOPMENT ONLY — set to False in production`.
+
+---
+
+## Category 3 — Dead Code / Quality
+
+### 3a. Remove `debug_task`
+
+**Finding:** `django/config/celery.py` contains `debug_task` with `print(f"Request: {self.request!r}")`. It is never registered in `CELERY_BEAT_SCHEDULE`, never called from views or tests. Dead code with a `print()` in production module.
+
+**Fix:** Delete the function entirely.
+
+### 3b. Remove dead whitenoise comment
+
+**Finding:** `django/config/settings.py` line 181 has a commented-out `STATICFILES_STORAGE = 'whitenoise...'` that was never used (Caddy serves static files). It creates confusion about which storage is active.
+
+**Fix:** Remove the commented line. Keep only the active `StaticFilesStorage` line.
+
+### 3c. Unify HTTP client — migrate `markdown_sync` to `requests`
+
+**Finding:** `github_client.py` uses `requests`; `markdown_sync.py` uses `urllib` (stdlib). Two different HTTP stacks for the same job: fetching from GitHub.
+
+**Fix:** Rewrite the URL fetch in `django/main/markdown_sync.py` using `requests.get()` with a consistent `timeout=15`. Remove `urllib.request`, `urllib.error` imports. Error handling maps `requests.HTTPError` / `requests.RequestException` to the same log paths as the current `HTTPError` / `URLError` handling. `requests` is already a declared dependency.
+
+### 3d. Fix `visitor_counter` context processor
+
+**Finding:** `visitor_counter` calls `PageView.get_instance()` which uses `get_or_create(id=1)` — a write-capable operation — on every request. This is unnecessary after the row exists.
+
+**Fix:** Replace with a read-only query:
+```python
+def visitor_counter(request):
+    instance = PageView.objects.filter(id=1).first()
+    return {"visitor_count": instance.count if instance else 0}
+```
+The `get_instance()` class method is still used by the middleware (legitimate write path), so keep it on the model.
+
+---
+
+## Category 4 — Old Packages / Upgrade
+
+### 4a. PostgreSQL 13 → 16
+
+**Finding:** `postgres:13` is EOL November 2025 — no security patches. Current stable is 16 (supported to Nov 2028) or 17.
+
+**Fix procedure (in-place major upgrade is not supported by Postgres Docker images):**
+
+1. On the droplet (with stack running): `docker exec <db_container> pg_dump -U $DOCKER_DB_USER $DOCKER_DB_NAME > ~/pg_backup_$(date +%F).sql`
+2. `make prod-down`
+3. `docker volume rm my_django_portfolio_postgres_data`
+4. Change `postgres:13` → `postgres:16` in `infra/docker-compose.prod.yml`
+5. `make prod-up` — new Postgres 16 container initializes fresh
+6. Wait for `db` healthy: `make prod-status`
+7. `docker exec -i <db_container> psql -U $DOCKER_DB_USER $DOCKER_DB_NAME < ~/pg_backup_$(date +%F).sql`
+8. Verify with `make prod-status` and spot-check the site.
+
+The spec change is: update the image tag in `infra/docker-compose.prod.yml`. The migration procedure is documented in the implementation plan as a manual step.
+
+### 4b. Python package patch updates
+
+**Fix:** Run `uv lock --upgrade-package pillow --upgrade-package requests --upgrade-package bleach --upgrade-package django` to get latest patch releases within the current major versions. Commit updated `uv.lock`. Do not upgrade Django to 5.2 in this PR (separate decision — potential breaking changes).
+
+### 4c. Node 20 → 22 in Dockerfile
+
+**Finding:** `FROM node:20-slim` in `infra/Dockerfile`. Node 20 LTS EOL April 2026, Node 22 LTS EOL April 2027.
+
+**Fix:** Single line change: `FROM node:22-slim`. No other changes required — the CSS build pipeline is Node-version-agnostic.
+
+---
+
+## Testing
+
+Each category has clear verification:
+
+| Category | Verification |
+|---|---|
+| 1a — ignore results | Check Redis db=1 stays empty after task run |
+| 1b — file cleanup | Admin: delete a Project with thumbnail → check `media/thumbnails/` |
+| 1c — disk monitoring | Run task manually via `manage.py shell`, check log output |
+| 2a — img filter | Render markdown with external img → confirm stripped; github.com img → passes |
+| 2b — env comment | Visual review |
+| 3a — debug_task | `make verify` passes, no `debug_task` in codebase |
+| 3b — whitenoise | `make verify` passes |
+| 3c — urllib → requests | Markdown sync still works; no urllib imports in markdown_sync |
+| 3d — visitor_counter | `make verify` passes; context processor returns count |
+| 4a — postgres | Site works post-restore; `psql --version` shows 16.x |
+| 4b — packages | `make verify` passes with new lock file |
+| 4c — Node 22 | `make verify` builds CSS successfully |
+
+Existing `make verify` suite catches regressions across all Python changes.
+
+---
+
+## Out of Scope
+
+- Django 5.1 → 5.2 LTS upgrade (separate issue, potential breaking changes)
+- Cache framework for context processors (over-engineered for portfolio traffic)
+- GHCR old image cleanup (already handled by `docker image prune -af` in deploy workflow)

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Build Tailwind CSS artifact
-FROM node:20-slim AS css-builder
+FROM node:22-slim AS css-builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:16
+    image: postgres:13
     restart: always
     # Use variables from the .env file for security
     environment:

--- a/infra/docker-compose.prod.yml
+++ b/infra/docker-compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:13
+    image: postgres:16
     restart: always
     # Use variables from the .env file for security
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "my_django_portfolio",
+  "name": "my-django-portfolio",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -971,9 +971,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -986,8 +986,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.4.tgz",
       "integrity": "sha512-1ZIUqtPITFbv/DxRmDr5/agPqJwF69d24m9qmM1939TJehgY539CtzeZRjbLt5G6fSy/7YqqYsfvoTEw9xUI2A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,11 @@ dependencies = [
     "gunicorn==23.0.0",
     "markdown==3.8.2",
     "packaging==25.0",
-    "pillow==12.1.1",
+    "pillow==12.2.0",
     "psycopg2-binary==2.9.10",
     "pymdown-extensions==10.16.1",
-    "requests==2.32.5",
+    "pyjwt==2.12.0",
+    "requests==2.33.0",
     "sqlparse==0.5.4",
     "tzdata==2025.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -244,6 +244,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pillow" },
     { name = "psycopg2-binary" },
+    { name = "pyjwt" },
     { name = "pymdown-extensions" },
     { name = "requests" },
     { name = "sqlparse" },
@@ -265,10 +266,11 @@ requires-dist = [
     { name = "gunicorn", specifier = "==23.0.0" },
     { name = "markdown", specifier = "==3.8.2" },
     { name = "packaging", specifier = "==25.0" },
-    { name = "pillow", specifier = "==12.1.1" },
+    { name = "pillow", specifier = "==12.2.0" },
     { name = "psycopg2-binary", specifier = "==2.9.10" },
+    { name = "pyjwt", specifier = "==2.12.0" },
     { name = "pymdown-extensions", specifier = "==10.16.1" },
-    { name = "requests", specifier = "==2.32.5" },
+    { name = "requests", specifier = "==2.33.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.11.10" },
     { name = "sqlparse", specifier = "==0.5.4" },
     { name = "tzdata", specifier = "==2025.2" },
@@ -286,35 +288,35 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.1.1"
+version = "12.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/42/5c74462b4fd957fcd7b13b04fb3205ff8349236ea74c7c375766d6c82288/pillow-12.1.1.tar.gz", hash = "sha256:9ad8fa5937ab05218e2b6a4cff30295ad35afd2f83ac592e68c0d871bb0fdbc4", size = 46980264, upload-time = "2026-02-11T04:23:07.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/11/6db24d4bd7685583caeae54b7009584e38da3c3d4488ed4cd25b439de486/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d242e8ac078781f1de88bf823d70c1a9b3c7950a44cdf4b7c012e22ccbcd8e4e", size = 4062689, upload-time = "2026-02-11T04:21:06.804Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c0/ce6d3b1fe190f0021203e0d9b5b99e57843e345f15f9ef22fcd43842fd21/pillow-12.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:02f84dfad02693676692746df05b89cf25597560db2857363a208e393429f5e9", size = 4138535, upload-time = "2026-02-11T04:21:08.452Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/c6/d5eb6a4fb32a3f9c21a8c7613ec706534ea1cf9f4b3663e99f0d83f6fca8/pillow-12.1.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:e65498daf4b583091ccbb2556c7000abf0f3349fcd57ef7adc9a84a394ed29f6", size = 3601364, upload-time = "2026-02-11T04:21:10.194Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a1/16c4b823838ba4c9c52c0e6bbda903a3fe5a1bdbf1b8eb4fff7156f3e318/pillow-12.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6c6db3b84c87d48d0088943bf33440e0c42370b99b1c2a7989216f7b42eede60", size = 5262561, upload-time = "2026-02-11T04:21:11.742Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ad/ad9dc98ff24f485008aa5cdedaf1a219876f6f6c42a4626c08bc4e80b120/pillow-12.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8b7e5304e34942bf62e15184219a7b5ad4ff7f3bb5cca4d984f37df1a0e1aee2", size = 4657460, upload-time = "2026-02-11T04:21:13.786Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/f1a4ea9a895b5732152789326202a82464d5254759fbacae4deea3069334/pillow-12.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:18e5bddd742a44b7e6b1e773ab5db102bd7a94c32555ba656e76d319d19c3850", size = 6232698, upload-time = "2026-02-11T04:21:15.949Z" },
-    { url = "https://files.pythonhosted.org/packages/95/f4/86f51b8745070daf21fd2e5b1fe0eb35d4db9ca26e6d58366562fb56a743/pillow-12.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc44ef1f3de4f45b50ccf9136999d71abb99dca7706bc75d222ed350b9fd2289", size = 8041706, upload-time = "2026-02-11T04:21:17.723Z" },
-    { url = "https://files.pythonhosted.org/packages/29/9b/d6ecd956bb1266dd1045e995cce9b8d77759e740953a1c9aad9502a0461e/pillow-12.1.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a8eb7ed8d4198bccbd07058416eeec51686b498e784eda166395a23eb99138e", size = 6346621, upload-time = "2026-02-11T04:21:19.547Z" },
-    { url = "https://files.pythonhosted.org/packages/71/24/538bff45bde96535d7d998c6fed1a751c75ac7c53c37c90dc2601b243893/pillow-12.1.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47b94983da0c642de92ced1702c5b6c292a84bd3a8e1d1702ff923f183594717", size = 7038069, upload-time = "2026-02-11T04:21:21.378Z" },
-    { url = "https://files.pythonhosted.org/packages/94/0e/58cb1a6bc48f746bc4cb3adb8cabff73e2742c92b3bf7a220b7cf69b9177/pillow-12.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:518a48c2aab7ce596d3bf79d0e275661b846e86e4d0e7dec34712c30fe07f02a", size = 6460040, upload-time = "2026-02-11T04:21:23.148Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/57/9045cb3ff11eeb6c1adce3b2d60d7d299d7b273a2e6c8381a524abfdc474/pillow-12.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a550ae29b95c6dc13cf69e2c9dc5747f814c54eeb2e32d683e5e93af56caa029", size = 7164523, upload-time = "2026-02-11T04:21:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/73/f2/9be9cb99f2175f0d4dbadd6616ce1bf068ee54a28277ea1bf1fbf729c250/pillow-12.1.1-cp313-cp313-win32.whl", hash = "sha256:a003d7422449f6d1e3a34e3dd4110c22148336918ddbfc6a32581cd54b2e0b2b", size = 6332552, upload-time = "2026-02-11T04:21:27.238Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/eb/b0834ad8b583d7d9d42b80becff092082a1c3c156bb582590fcc973f1c7c/pillow-12.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:344cf1e3dab3be4b1fa08e449323d98a2a3f819ad20f4b22e77a0ede31f0faa1", size = 7040108, upload-time = "2026-02-11T04:21:29.462Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/7d/fc09634e2aabdd0feabaff4a32f4a7d97789223e7c2042fd805ea4b4d2c2/pillow-12.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c0dd1636633e7e6a0afe7bf6a51a14992b7f8e60de5789018ebbdfae55b040a", size = 2453712, upload-time = "2026-02-11T04:21:31.072Z" },
-    { url = "https://files.pythonhosted.org/packages/19/2a/b9d62794fc8a0dd14c1943df68347badbd5511103e0d04c035ffe5cf2255/pillow-12.1.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0330d233c1a0ead844fc097a7d16c0abff4c12e856c0b325f231820fee1f39da", size = 5264880, upload-time = "2026-02-11T04:21:32.865Z" },
-    { url = "https://files.pythonhosted.org/packages/26/9d/e03d857d1347fa5ed9247e123fcd2a97b6220e15e9cb73ca0a8d91702c6e/pillow-12.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5dae5f21afb91322f2ff791895ddd8889e5e947ff59f71b46041c8ce6db790bc", size = 4660616, upload-time = "2026-02-11T04:21:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ec/8a6d22afd02570d30954e043f09c32772bfe143ba9285e2fdb11284952cd/pillow-12.1.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e0c664be47252947d870ac0d327fea7e63985a08794758aa8af5b6cb6ec0c9c", size = 6269008, upload-time = "2026-02-11T04:21:36.623Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/1d/6d875422c9f28a4a361f495a5f68d9de4a66941dc2c619103ca335fa6446/pillow-12.1.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:691ab2ac363b8217f7d31b3497108fb1f50faab2f75dfb03284ec2f217e87bf8", size = 8073226, upload-time = "2026-02-11T04:21:38.585Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/cd/134b0b6ee5eda6dc09e25e24b40fdafe11a520bc725c1d0bbaa5e00bf95b/pillow-12.1.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e9e8064fb1cc019296958595f6db671fba95209e3ceb0c4734c9baf97de04b20", size = 6380136, upload-time = "2026-02-11T04:21:40.562Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a9/7628f013f18f001c1b98d8fffe3452f306a70dc6aba7d931019e0492f45e/pillow-12.1.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:472a8d7ded663e6162dafdf20015c486a7009483ca671cece7a9279b512fcb13", size = 7067129, upload-time = "2026-02-11T04:21:42.521Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f8/66ab30a2193b277785601e82ee2d49f68ea575d9637e5e234faaa98efa4c/pillow-12.1.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:89b54027a766529136a06cfebeecb3a04900397a3590fd252160b888479517bf", size = 6491807, upload-time = "2026-02-11T04:21:44.22Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0b/a877a6627dc8318fdb84e357c5e1a758c0941ab1ddffdafd231983788579/pillow-12.1.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:86172b0831b82ce4f7877f280055892b31179e1576aa00d0df3bb1bbf8c3e524", size = 7190954, upload-time = "2026-02-11T04:21:46.114Z" },
-    { url = "https://files.pythonhosted.org/packages/83/43/6f732ff85743cf746b1361b91665d9f5155e1483817f693f8d57ea93147f/pillow-12.1.1-cp313-cp313t-win32.whl", hash = "sha256:44ce27545b6efcf0fdbdceb31c9a5bdea9333e664cda58a7e674bb74608b3986", size = 6336441, upload-time = "2026-02-11T04:21:48.22Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/44/e865ef3986611bb75bfabdf94a590016ea327833f434558801122979cd0e/pillow-12.1.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a285e3eb7a5a45a2ff504e31f4a8d1b12ef62e84e5411c6804a42197c1cf586c", size = 7045383, upload-time = "2026-02-11T04:21:50.015Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/c6/f4fb24268d0c6908b9f04143697ea18b0379490cb74ba9e8d41b898bd005/pillow-12.1.1-cp313-cp313t-win_arm64.whl", hash = "sha256:cc7d296b5ea4d29e6570dabeaed58d31c3fea35a633a69679fb03d7664f43fb3", size = 2456104, upload-time = "2026-02-11T04:21:51.633Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
 ]
 
 [[package]]
@@ -350,11 +352,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/10/e8192be5f38f3e8e7e046716de4cae33d56fd5ae08927a823bb916be36c1/pyjwt-2.12.0.tar.gz", hash = "sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02", size = 102511, upload-time = "2026-03-12T17:15:30.831Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+    { url = "https://files.pythonhosted.org/packages/15/70/70f895f404d363d291dcf62c12c85fdd47619ad9674ac0f53364d035925a/pyjwt-2.12.0-py3-none-any.whl", hash = "sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e", size = 29700, upload-time = "2026-03-12T17:15:29.257Z" },
 ]
 
 [[package]]
@@ -414,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -422,9 +424,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]
@@ -481,11 +483,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

  Summary
  
  - Security hardening — bleach restricted to GitHub-only img src domains; 5 Dependabot CVEs patched (pillow, requests, urllib3, PyJWT,
  picomatch)
  - Disk monitoring — new check_disk_usage_task (Celery Beat, daily 06:00) with critical/warning/ok levels; disk info panel on about page for
  staff
  - Media file cleanup — Django signals (pre_save, post_delete) auto-delete orphaned thumbnails and markdown files instead of leaving them on
  disk
  - urllib → requests — markdown sync rewritten to use requests library; consistent error handling, size limit and HTML detection
  - Dead code removed — debug_task with print() in celery.py; commented-out WhiteNoise setting
  - Celery — CELERY_TASK_IGNORE_RESULT = True stops writing task results to Redis
  - DX — make dev-up prints frontend/admin/db URLs after startup

  Test plan

  - make verify — wszystkie 26 testów zielone, ruff czysty
  - Sprawdź panel dysku na /about jako staff
  - Sprawdź że po usunięciu projektu pliki znikają z media/
  - Sprawdź że markdown sync pobiera README z GitHub
  - make dev-up — zweryfikuj że linki są wypisane po starcie
